### PR TITLE
Give notes a popup of their own, with an x that closes it

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ desktop is reflowed to fit and no resampling happens at all. Resize the terminal
 window and the remote desktop follows.
 
 When a server will not do that — `x11vnc` usually refuses, and some are not built
-for it — the status line says why and falls back to scaling or a 1:1 view you can
+for it — a notification says why and falls back to scaling or a 1:1 view you can
 pan.
 
 ## Requirements
@@ -239,7 +239,7 @@ make desktop-stop
 TigerVNC on purpose: `-AcceptSetDesktopSize` defaults to on, so the negotiation is
 genuinely exercised rather than quietly falling back. Point the client at an `x11vnc`
 instance instead to exercise the other path — it usually answers "administratively
-prohibited", which is what the status line has to explain.
+prohibited", which is what the notification has to explain.
 
 The container publishes to `127.0.0.1` and nothing else, because VNC's password auth
 is DES with an eight-character key and the session that follows is in the clear.

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,6 +29,7 @@ use crate::term::{Metrics, TerminalGuard, kitty};
 use crate::ui::menu::{self, Hit, Menu};
 use crate::ui::status;
 use crate::ui::theme::Theme;
+use crate::ui::toast::Toast;
 
 /// How long to wait for the TCP connection.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -42,9 +43,6 @@ const UPDATE_WATCHDOG: Duration = Duration::from_secs(1);
 /// long after the last one keeps us from asking the server to resize dozens of
 /// times.
 const RESIZE_DEBOUNCE: Duration = Duration::from_millis(250);
-
-/// How long a note stays in the status line.
-const NOTE_LINGER: Duration = Duration::from_secs(4);
 
 /// Floor on the gap between two update requests, so a server that answers an
 /// incremental request instantly cannot spin us at full speed.
@@ -331,7 +329,8 @@ struct Session {
     /// the image over them does not do it: the image sits below the text.
     clear_menu: bool,
     show_stats: bool,
-    note: Option<(String, Instant)>,
+    /// The notification popup in the top-right corner, and the note it is showing.
+    toast: Toast,
 
     fps: FpsMeter,
     last_stats: FrameStats,
@@ -390,7 +389,7 @@ impl Session {
             show_menu: false,
             clear_menu: false,
             show_stats: false,
-            note: None,
+            toast: Toast::default(),
             fps: FpsMeter::new(),
             last_stats: FrameStats::default(),
             dropped: 0,
@@ -801,11 +800,42 @@ impl Session {
                 let at = self.renderer.layout().terminal_px_to_dst(tx, ty);
                 self.renderer.move_cursor(at);
 
-                // The menu takes the pointer while it is up. Nothing goes through to
-                // the remote: a click meant for a menu item must not also land on
-                // whatever is behind it.
+                // The popup is offered the pointer before the menu is, because it is
+                // drawn over the menu: half the notes there are arrive from a menu item,
+                // and a click on one leaves the box up, so a cross that the menu could
+                // swallow is a cross that does nothing most of the time it is on screen.
+                //
+                // Only a press on the cross is taken. The rest of the box is not a
+                // target, so the pointer goes on reaching whatever is underneath as it
+                // crosses a note that has already been read -- and a release is never
+                // swallowed, which would leave a button held down over there.
+                let (col, row) = self.input.terminal_cell(&mouse, &self.metrics);
+                let on_close = self.toast.on_close(&self.metrics, col, row);
+                self.toast.set_hover(on_close);
+                let pressed = matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left));
+                if pressed && let Some(target) = self.toast.close_cells(&self.metrics) {
+                    // A click that missed by a cell and one the popup never saw look the
+                    // same from the outside; this is what tells them apart.
+                    tracing::debug!("click at cell {col},{row}; the cross wants {target:?}");
+                }
+                if on_close && pressed {
+                    if self.toast.dismiss() {
+                        self.renderer.mark_all();
+                    }
+                    return Ok(());
+                }
+
+                // The menu takes the rest of the pointer while it is up. Nothing goes
+                // through to the remote: a click meant for a menu item must not also land
+                // on whatever is behind it.
                 if self.show_menu {
-                    self.on_menu_mouse(mouse).await?;
+                    // Except where the popup covers it: the box lights nothing under a
+                    // pointer that is on the cross drawn over it.
+                    if on_close {
+                        self.menu.clear_hover();
+                    } else {
+                        self.on_menu_mouse(mouse).await?;
+                    }
                     return Ok(());
                 }
 
@@ -1180,8 +1210,13 @@ impl Session {
     }
 
     fn draw(&mut self) -> Result<()> {
+        // A note that has run out has to come off the screen, and the screen it was
+        // over has to be drawn back: work of its own, whether or not a frame arrived.
+        if self.toast.expire() {
+            self.renderer.mark_all();
+        }
         let has_work = self.renderer.has_work();
-        if !has_work && self.note.is_none() && !self.show_menu && !self.clear_menu {
+        if !has_work && !self.toast.is_live() && !self.show_menu && !self.clear_menu {
             // Still repaint the status line often enough for the clock-like
             // fields to stay honest, but not every tick.
             if self.fps.since_last() < Duration::from_millis(500) {
@@ -1199,6 +1234,7 @@ impl Session {
             self.menu.clear(&mut buf, &self.metrics);
             self.clear_menu = false;
         }
+        self.toast.clear(&mut buf);
         let stats = self.renderer.compose(&self.fb, &mut buf);
         if stats.tiles > 0 {
             self.last_stats = stats;
@@ -1207,6 +1243,10 @@ impl Session {
         if self.show_menu {
             self.menu.draw(&mut buf, &self.metrics, self.menu_state());
         }
+        // Last of the chrome, so a note that arrives with the menu open lands on top
+        // of it rather than under it.
+        self.toast
+            .draw(&mut buf, &self.metrics, self.theme.palette());
         if self.caps.sync_output {
             kitty::end_sync(&mut buf);
         }
@@ -1214,6 +1254,7 @@ impl Session {
         match self.writer.submit(buf) {
             Ok(()) => {
                 self.renderer.commit();
+                self.toast.commit();
                 self.fps.tick();
             }
             Err(Busy::Full(buf)) => {
@@ -1242,16 +1283,6 @@ impl Session {
         rest.push_str(&format!("  {}", describe(&layout)));
         if self.view_only {
             rest.push_str("  view-only");
-        }
-
-        // The note comes after the dot below, so it is built here rather than pushed.
-        let mut note = String::new();
-        if let Some((text, at)) = &self.note {
-            if at.elapsed() < NOTE_LINGER {
-                note = format!("  -- {text}");
-            } else {
-                self.note = None;
-            }
         }
 
         // The one binding worth naming, because it opens the menu the rest of them are
@@ -1286,7 +1317,6 @@ impl Session {
         if self.input.is_armed() {
             left.push(ink.accent("  ● CMD"));
         }
-        left.push(ink.text(&note));
 
         status::draw(
             buf,
@@ -1340,9 +1370,15 @@ impl Session {
         self.set_note("remote clipboard copied".into());
     }
 
+    /// Put a note up in the notification popup.
     fn set_note(&mut self, note: String) {
         tracing::debug!("{note}");
-        self.note = Some((note, Instant::now()));
+        // A note landing on top of one already up takes the old box off the screen with
+        // it, and the remote screen under the cells it no longer covers has to come
+        // back -- the same repair the menu asks for when it is dismissed.
+        if self.toast.show(note) {
+            self.renderer.mark_all();
+        }
     }
 }
 

--- a/src/term/kitty.rs
+++ b/src/term/kitty.rs
@@ -74,6 +74,10 @@ pub const OVERLAY_IMAGE_ID: u32 = IMAGE_ID_BASE + 0x10000;
 /// on so it is composited over it rather than under.
 pub const MENU_HIGHLIGHT_IMAGE_ID: u32 = OVERLAY_IMAGE_ID + 1;
 
+/// Image id for the notification popup's backdrop, above both of the menu's: a note
+/// that arrives while the menu is open belongs on top of it, not under it.
+pub const TOAST_IMAGE_ID: u32 = MENU_HIGHLIGHT_IMAGE_ID + 1;
+
 /// Where a tile goes and how big it is.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Placement {

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -1,5 +1,5 @@
-//! The command menu: the overlay listing the prefix-key commands, and the one
-//! piece of chrome you can point at.
+//! The command menu: the overlay listing the prefix-key commands, and the piece of
+//! chrome with more than one thing on it you can point at.
 //!
 //! Laid out with ratatui, but not driven by it. A ratatui `Terminal` owns the
 //! screen and diffs its way to the next one, which would put it in charge of the
@@ -139,7 +139,7 @@ fn option_spans(options: &[Option_]) -> Vec<(&Option_, u16, u16)> {
 ///
 /// Right-aligned, like every shortcut, so it starts where it ends up rather than at
 /// a fixed offset. Drawing and hit testing both come through here, or a click would
-/// land next to the word rather than on it.
+/// land next to the button rather than on it.
 fn close_span(close: &str, width: u16) -> (u16, u16) {
     (width.saturating_sub(cells(close)), width)
 }
@@ -225,7 +225,7 @@ impl Menu {
         let entries = vec![
             Entry::Title {
                 name: "Command menu".into(),
-                close: "esc".into(),
+                close: super::CLOSE.into(),
             },
             Entry::Blank,
             Entry::Section("Session".into()),
@@ -333,14 +333,12 @@ impl Menu {
     /// what the cells behind it are coloured -- one function, so the image and the
     /// colour cannot land on different cells.
     ///
-    /// A command's target is its whole row. An option's is the option itself, and the
-    /// title's is the word that dismisses: those rows hold something other than the
-    /// one target, and a bar across all of it would say the pointer is on things it
-    /// is not.
+    /// A command's target is its whole row, and a bar across the row is the answer. An
+    /// option's is the option itself, that row holding several, and a bar across all of it
+    /// would say the pointer is on things it is not. The title's button gets no bar at all.
     fn hover_bar(&self, area: Rect) -> Option<Rect> {
         let (index, command) = self.hover?;
         let y = area.y + PAD_Y + u16::try_from(index).ok()?;
-        let inner = area.width.saturating_sub(PAD_X * 2);
         let span = |start: u16, width: u16| {
             Some(Rect {
                 x: area.x + PAD_X + start,
@@ -356,10 +354,11 @@ impl Menu {
                     .find(|(option, ..)| option.command == command)?;
                 span(start, option.width())
             }
-            Entry::Title { close, .. } => {
-                let (start, end) = close_span(close, inner);
-                span(start, end - start)
-            }
+            // The one target with no bar: it is a button in the palette's own styling,
+            // which lifts by colour alone, and a bar behind it would be a second mark for
+            // one thing -- as well as the one difference between this button and the
+            // popup's, which has no bar to give it (see `theme::Palette::close_button`).
+            Entry::Title { .. } => None,
             _ => Some(Rect {
                 x: area.x,
                 y,
@@ -532,14 +531,10 @@ impl Widget for MenuView<'_> {
                     ))
                     .render(row, buf);
                     // A target, so it lifts under the pointer like everything else
-                    // rather than sitting there as a label that happens to work.
-                    let style = if hovered(Command::Menu) {
-                        Style::new()
-                            .fg(colour(ink.accent))
-                            .add_modifier(Modifier::UNDERLINED)
-                    } else {
-                        Style::new().fg(colour(ink.muted))
-                    };
+                    // rather than sitting there as a label that happens to work. The
+                    // styling is the palette's rather than this file's, the popup
+                    // carrying the same button (see `toast`).
+                    let style = ink.close_button(hovered(Command::Menu));
                     Line::from(Span::styled(close.as_str(), style))
                         .right_aligned()
                         .render(row, buf);
@@ -617,7 +612,8 @@ fn split(buf: &mut Buffer, row: Rect, left: &str, right: &str, style: Style, ink
 mod tests {
     use super::*;
     use crate::cli::ScaleMode;
-    use crate::ui::theme::probe::bg;
+    use crate::ui::CLOSE;
+    use crate::ui::theme::probe::{bg, fg};
 
     /// A settled state, for the tests that reason about geometry rather than marks.
     fn state() -> State {
@@ -922,28 +918,51 @@ mod tests {
     }
 
     #[test]
-    fn the_word_in_the_title_is_a_target_and_the_name_beside_it_is_not() {
+    fn the_button_in_the_title_is_a_target_and_the_name_beside_it_is_not() {
         let mut menu = Menu::new('a');
         let m = metrics(100, 40);
         let area = menu.area(&m).unwrap();
         let row = area.y + PAD_Y;
-        // "esc" is pushed against the right edge of the padded area, so it ends there.
+        // The button is pushed against the right edge of the padded area, so it ends
+        // there.
         let end = area.x + area.width - PAD_X;
         let dismiss = Hit::Item {
             index: 0,
             command: Command::Menu,
         };
-        for col in [end - 3, end - 2, end - 1] {
-            assert_eq!(menu.hit(&m, col, row), dismiss, "column {col} of the title");
-        }
+        // One cell of mark and one cell of target: what a click acts on is the cell the
+        // button is drawn on, with nothing either side of it standing in.
+        assert_eq!(menu.hit(&m, end - 1, row), dismiss, "the button");
         // Neither the name at the other end nor the space between them.
         assert_eq!(menu.hit(&m, area.x + PAD_X, row), Hit::Inside, "the name");
-        assert_eq!(menu.hit(&m, end - 4, row), Hit::Inside, "the gap");
+        assert_eq!(menu.hit(&m, end - 2, row), Hit::Inside, "the gap");
 
-        // And the bar covers the word, not the row: the rest of it does nothing.
+        // And it lifts by colour alone: no bar behind it, which would be a second mark for
+        // one thing and the one way this button and the popup's -- which has no bar to be
+        // given -- could look unlike each other.
         menu.set_hover(menu.hit(&m, end - 1, row));
-        let bar = menu.hover_bar(area).expect("nothing highlighted");
-        assert_eq!((bar.x, bar.width, bar.y), (end - 3, 3, row));
+        assert_eq!(
+            menu.hover_bar(area),
+            None,
+            "the title's button should have no bar"
+        );
+
+        let mut out = Vec::new();
+        menu.draw(&mut out, &m, state());
+        let text = String::from_utf8(out).unwrap();
+        let ink = state().theme.palette();
+        assert!(
+            !text.contains(&bg(ink.hover)),
+            "nothing else is hovered, so nothing should carry the lift: {text:?}"
+        );
+        // The accent is the sections' colour too, so it is the run carrying the button
+        // that has to be found rather than the first run in that ink.
+        let lit = text.split(&fg(ink.accent)).any(|run| {
+            run.split("\x1b[0m")
+                .next()
+                .is_some_and(|run| run.contains(CLOSE))
+        });
+        assert!(lit, "the button should be in the accent: {text:?}");
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,3 +13,9 @@ pub mod menu;
 mod paint;
 pub mod status;
 pub mod theme;
+pub mod toast;
+
+/// The button that takes a piece of chrome off the screen: the menu's title carries one
+/// and so does the notification popup. One string for both, because they are the same
+/// control and two copies of it could come to disagree about what it looks like.
+pub const CLOSE: &str = "x";

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,9 +1,9 @@
 //! The two palettes the chrome can wear.
 //!
-//! One palette covers both pieces, because they are one piece of chrome as far as
-//! the eye is concerned: the bar names what you are connected to and the menu lists
-//! what you can do about it, and a light box over a dark bar would read as two
-//! programs.
+//! One palette covers every piece, because they are one piece of chrome as far as
+//! the eye is concerned: the bar names what you are connected to, the menu lists what
+//! you can do about it and the popup says what came of it, and a light box over a dark
+//! bar would read as two programs.
 //!
 //! Every colour is kept as bytes rather than as a `ratatui::Color`. The menu needs
 //! both forms -- its backdrop and its highlight are images, because a cell colour
@@ -39,8 +39,9 @@ impl Theme {
 
 /// Everything either piece of chrome is allowed to paint with.
 pub struct Palette {
-    /// The menu's background, and the ink on it: labels, then the shortcuts beside
-    /// them, which are quieter because you read them second.
+    /// The surface the menu and the notification popup are drawn on, and the ink on
+    /// it: labels, then the shortcuts beside them, which are quieter because you read
+    /// them second.
     pub paper: Rgb,
     pub ink: Rgb,
     pub muted: Rgb,
@@ -72,6 +73,25 @@ impl Palette {
     /// prefix waits for the key that follows it.
     pub fn accent<'a>(&self, text: &'a str) -> Span<'a> {
         Span::styled(text, Style::new().fg(colour(self.accent)))
+    }
+
+    /// The button that closes a piece of chrome, quiet or under the pointer.
+    ///
+    /// The menu's title carries one and so does the notification popup, and the pointer
+    /// has to do the same thing to both -- so the styling is defined once here rather
+    /// than at each of them, where two copies would drift into two conventions for one
+    /// control.
+    ///
+    /// It lifts by colour alone: grey to the accent, with no ground behind it and nothing
+    /// drawn under it. Three cells of bracketed mark changing colour is a plain enough
+    /// answer to being pointed at, and a bar and a rule on top of that are two more marks
+    /// saying the same thing. The menu makes an exception of this row for the same reason
+    /// (see `menu::Menu::hover_bar`).
+    pub fn close_button(&self, hovered: bool) -> Style {
+        match hovered {
+            true => Style::new().fg(colour(self.accent)),
+            false => Style::new().fg(colour(self.muted)),
+        }
     }
 }
 
@@ -135,6 +155,28 @@ mod tests {
                 p.paper, p.bar,
                 "{theme:?}: the menu is not the bar's colour"
             );
+        }
+    }
+
+    #[test]
+    fn a_close_button_lights_by_colour_and_nothing_else() {
+        // The menu's title and the popup both carry one, and one definition serves both,
+        // so this is the whole of what either of them does to it: grey to the accent, with
+        // no ground behind it and no rule under it.
+        for theme in [Theme::Dark, Theme::Light] {
+            let p = theme.palette();
+            let quiet = p.close_button(false);
+            assert_eq!(quiet.fg, Some(colour(p.muted)), "{theme:?}");
+
+            let lit = p.close_button(true);
+            assert_eq!(lit.fg, Some(colour(p.accent)), "{theme:?}");
+            for state in [quiet, lit] {
+                assert_eq!(state.bg, None, "{theme:?}: the button has no ground");
+                assert!(
+                    state.add_modifier.is_empty(),
+                    "{theme:?}: the colour is the whole of it"
+                );
+            }
         }
     }
 

--- a/src/ui/toast.rs
+++ b/src/ui/toast.rs
@@ -1,0 +1,709 @@
+//! The notification popup.
+//!
+//! Notes -- a resize refused, a scaling mode adopted, the clipboard picked up -- used
+//! to be tacked onto the status line, where they shared a row with the figures and
+//! were the first thing a narrow terminal cut off. They land in the top-right corner
+//! instead, held off it by a margin, and take themselves off again after [`LINGER`].
+//!
+//! Everything the popup needs the menu needed first, and for the same reasons: a
+//! backdrop that is an image, because a cell colour under the remote screen is never
+//! seen (see `menu`), and an explicit blanking of its cells when it goes, because the
+//! message is text and no repaint of the tiles below it can erase that.
+//!
+//! It can also be dismissed before its time, by the `x` at the right of the message: the
+//! same button the menu's title carries, and a click acts on exactly the cell it is drawn
+//! on, with no slack around it. Under the pointer it lifts exactly as the menu's does, the
+//! palette defining that for both of them (see `theme`): by colour, which is also the one
+//! kind of highlight that needs no image of its own out here.
+//!
+//! The rest of the box is not a target, so the pointer goes on reaching the remote screen
+//! underneath as it crosses a note it has already read. The session offers the pointer
+//! here before the menu, the popup being drawn over the menu -- see `session`.
+
+use std::io::Write as _;
+use std::time::{Duration, Instant};
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Position, Rect};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Padding, Widget};
+
+use super::paint::write_cells;
+use super::theme::{Palette, colour};
+// The button is the menu's, not one of the popup's own: the way to close a thing should
+// look the same wherever it is.
+use super::CLOSE;
+use crate::term::{Metrics, kitty};
+
+/// How long a note stays on screen.
+pub const LINGER: Duration = Duration::from_secs(4);
+
+/// Breathing room inside the popup, and between the popup and the corner it sits in.
+/// Two columns to the row in both, because a cell is about twice as tall as it is
+/// wide, so the gap reads as the same gap in both directions.
+const PAD_X: u16 = 2;
+const PAD_Y: u16 = 1;
+const MARGIN_X: u16 = 2;
+const MARGIN_Y: u16 = 1;
+
+/// Space between the message and the button that closes it, so the two do not read as
+/// one word.
+const GAP: u16 = 3;
+
+/// Least of a message worth truncating to. Below this the box would be a couple of
+/// letters over the remote screen, which says less than no box at all.
+const MIN_TEXT: u16 = 12;
+
+/// What the box holds beside the message: the gap, the button, and the padding either
+/// side of the lot.
+const CHROME: u16 = GAP + BUTTON + PAD_X * 2;
+
+/// Cells the button covers, which the layout needs as a number. A `const` cannot count
+/// them, so this is the one thing that could come to disagree with `CLOSE`, and the
+/// assertion that it does not sits next to it.
+const BUTTON: u16 = 1;
+const _: () = assert!(CLOSE.len() == BUTTON as usize);
+
+/// Width of the message as it will be drawn.
+///
+/// Measured rather than counted, as the status line measures its own: a note can carry
+/// a server's name, and a name in something wider than Latin-1 would be measured short.
+fn width_of(text: &str) -> u16 {
+    u16::try_from(Line::raw(text).width()).unwrap_or(u16::MAX)
+}
+
+/// Where the popup goes, in zero-based screen cells, or `None` when there is not
+/// enough screen to put it on.
+///
+/// The width follows the message, so drawing and erasing both come through here
+/// rather than each working it out for itself.
+fn area(metrics: &Metrics, text: &str) -> Option<Rect> {
+    let height = 1 + PAD_Y * 2;
+    // Measured against the image rows: the bar owns the bottom one, and a popup over
+    // it would be one piece of chrome on top of another.
+    if MARGIN_Y + height > metrics.image_rows() {
+        return None;
+    }
+    // A margin either side, so a long message is truncated at the left edge of the box
+    // rather than run off the left edge of the screen.
+    let room = metrics.cols.checked_sub(MARGIN_X * 2)?;
+    let wanted = width_of(text).saturating_add(CHROME);
+    let width = wanted.min(room);
+    // The button is not what gets truncated away: a note that cannot be dismissed is
+    // worse than one that says a little less.
+    if width < wanted.min(MIN_TEXT + CHROME) {
+        return None;
+    }
+    Some(Rect {
+        x: metrics.cols - MARGIN_X - width,
+        y: MARGIN_Y,
+        width,
+        height,
+    })
+}
+
+/// The cells the button is drawn on: the last of the padded inside, on the message's own
+/// row. Drawing and hit testing both come through here, so a click cannot land beside
+/// what it looks like it is on.
+fn close_at(area: Rect) -> Rect {
+    Rect {
+        x: area.x + area.width - PAD_X - BUTTON,
+        y: area.y + PAD_Y,
+        width: BUTTON,
+        height: 1,
+    }
+}
+
+/// The note on screen, and whatever the last one left behind.
+#[derive(Default)]
+pub struct Toast {
+    /// The message and when it went up.
+    showing: Option<(String, Instant)>,
+    /// The cells the popup was last drawn on. Recorded rather than worked out again
+    /// when it comes off: the box is as wide as its message, and a message replaced or
+    /// a terminal resized in between would put it somewhere else.
+    drawn: Option<Rect>,
+    /// Cells a popup has left behind, which stay written until they are blanked.
+    stale: Option<Rect>,
+    /// The pointer is on the button, which is drawn lit while it is.
+    hover: bool,
+}
+
+impl Toast {
+    /// Put a note up, replacing whatever was there.
+    ///
+    /// True when the popup that went has left cells behind, which is when the remote
+    /// screen under them has to be drawn back.
+    pub fn show(&mut self, text: String) -> bool {
+        // The outgoing box is not simply drawn over: a shorter message makes a
+        // narrower one, and the cells past it would keep the old backdrop.
+        let left_behind = self.take_down();
+        self.showing = Some((text, Instant::now()));
+        left_behind
+    }
+
+    /// Take a note that has run out off the screen. True on the frame it goes, with
+    /// the same meaning as [`Toast::show`]'s.
+    pub fn expire(&mut self) -> bool {
+        match &self.showing {
+            Some((_, at)) if at.elapsed() >= LINGER => self.take_down(),
+            _ => false,
+        }
+    }
+
+    /// Take a note off before its linger is up, the button having been clicked. True
+    /// with the same meaning as [`Toast::show`]'s.
+    pub fn dismiss(&mut self) -> bool {
+        self.take_down()
+    }
+
+    /// Is the pointer at zero-based cell `(col, row)` on the button?
+    ///
+    /// False whenever there is no popup, or none was drawn: a note too big for the
+    /// screen has no button to click on either.
+    pub fn on_close(&self, metrics: &Metrics, col: u16, row: u16) -> bool {
+        let Some((text, _)) = &self.showing else {
+            return false;
+        };
+        let Some(area) = area(metrics, text) else {
+            return false;
+        };
+        close_at(area).contains(Position::new(col, row))
+    }
+
+    /// Light the button, or put it out, as the pointer arrives on it or leaves.
+    pub fn set_hover(&mut self, on_close: bool) {
+        self.hover = on_close;
+    }
+
+    /// The cells a click has to land on to close the popup, for the log. A click that
+    /// missed by a cell and one the popup never heard about look the same from the
+    /// outside, and this is what tells them apart.
+    pub fn close_cells(&self, metrics: &Metrics) -> Option<Rect> {
+        let (text, _) = self.showing.as_ref()?;
+        Some(close_at(area(metrics, text)?))
+    }
+
+    /// Is there a note up? A session with one has something to redraw even when no
+    /// frame has arrived.
+    pub fn is_live(&self) -> bool {
+        self.showing.is_some()
+    }
+
+    fn take_down(&mut self) -> bool {
+        self.showing = None;
+        // Or the next note would arrive with its button already lit, before the pointer
+        // has moved to say so.
+        self.hover = false;
+        match self.drawn.take() {
+            Some(area) => {
+                self.stale = Some(area);
+                true
+            }
+            // Never drawn -- a note replaced inside a single frame -- so there is
+            // nothing on the screen to take off.
+            None => false,
+        }
+    }
+
+    /// Blank the cells the last popup left, if any.
+    ///
+    /// Goes out before the frame's tiles, as the menu's erase does: a terminal may
+    /// treat clearing a cell as dropping the placement under it.
+    pub fn clear(&self, out: &mut Vec<u8>) {
+        let Some(area) = self.stale else {
+            return;
+        };
+        out.extend_from_slice(b"\x1b[0m");
+        for y in area.top()..area.bottom() {
+            let _ = write!(out, "\x1b[{};{}H", y + 1, area.x + 1);
+            out.extend(std::iter::repeat_n(b' ', usize::from(area.width)));
+        }
+        kitty::delete_image(out, kitty::TOAST_IMAGE_ID);
+    }
+
+    /// The frame carrying the erase reached the terminal, so the cells are clean.
+    /// A dropped frame leaves the record standing and the next one blanks them again.
+    pub fn commit(&mut self) {
+        self.stale = None;
+    }
+
+    /// Draw the note, if there is one, over the top-right of the remote screen.
+    pub fn draw(&mut self, out: &mut Vec<u8>, metrics: &Metrics, ink: &Palette) {
+        let Some((text, _)) = &self.showing else {
+            return;
+        };
+        let Some(area) = area(metrics, text) else {
+            return;
+        };
+
+        // The backdrop first and the message on it. Above the menu's two ids, so a
+        // note that lands while the menu is open is composited over it rather than
+        // buried under it.
+        kitty::place_solid(
+            out,
+            kitty::TOAST_IMAGE_ID,
+            usize::from(area.x) + 1,
+            usize::from(area.y) + 1,
+            usize::from(area.width),
+            usize::from(area.height),
+            ink.paper,
+        );
+        let mut buf = Buffer::empty(area);
+        let block = Block::new()
+            .padding(Padding::symmetric(PAD_X, PAD_Y))
+            .style(Style::new().bg(colour(ink.paper)).fg(colour(ink.ink)));
+        let inner = block.inner(area);
+        block.render(area, &mut buf);
+        // Given the room the button and the gap leave rather than the whole inside, so a
+        // long message is clipped short of the button instead of up against it. One line
+        // however long it is: a wrapped note is a box that changes height as it is read.
+        let said = Rect {
+            width: inner.width.saturating_sub(GAP + BUTTON),
+            ..inner
+        };
+        Line::from(Span::styled(
+            text.as_str(),
+            Style::new().fg(colour(ink.ink)),
+        ))
+        .render(said, &mut buf);
+        // The palette's own styling for the button, quiet or lit, which is the styling the
+        // menu's title gives the same button: one definition, so pointing at either does
+        // the same thing. Colour and nothing else, which is also the one kind of highlight
+        // that needs no image of its own -- a background here would be painted under the
+        // remote screen and never seen.
+        Line::from(Span::styled(CLOSE, ink.close_button(self.hover)))
+            .render(close_at(area), &mut buf);
+        write_cells(out, &buf);
+
+        self.drawn = Some(area);
+    }
+
+    /// Push the note back in time, so a test can reach its expiry without waiting out
+    /// the linger.
+    #[cfg(test)]
+    fn age(&mut self, by: Duration) {
+        if let Some((_, at)) = &mut self.showing
+            && let Some(earlier) = at.checked_sub(by)
+        {
+            *at = earlier;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::theme::probe::{bg, fg};
+    use crate::ui::theme::{Rgb, Theme};
+
+    fn ink() -> &'static Palette {
+        Theme::Dark.palette()
+    }
+
+    /// Was the image itself dropped? `d=I` frees the image; the lower-case `d=i` before
+    /// every placement only releases the placement on it.
+    fn dropped(text: &str, id: u32) -> bool {
+        text.contains(&format!("a=d,d=I,i={id},"))
+    }
+
+    /// What was written in `colour`: everything from where it was set up to the reset
+    /// that ends the run. Nothing is assumed about the escapes in between -- a run
+    /// names its background too, and in whichever order `paint` happens to emit them.
+    fn inked(text: &str, colour: Rgb) -> String {
+        let run = text
+            .split(&fg(colour))
+            .nth(1)
+            .unwrap_or_else(|| panic!("{colour:?} was never used: {text:?}"));
+        run.split("\x1b[0m").next().unwrap_or("").to_string()
+    }
+
+    fn metrics(cols: u16, rows: u16) -> Metrics {
+        Metrics {
+            cols,
+            rows,
+            px_w: u32::from(cols) * 8,
+            px_h: u32::from(rows) * 16,
+            cell_w: 8,
+            cell_h: 16,
+        }
+    }
+
+    /// A popup on screen, and the bytes that put it there.
+    fn shown(m: &Metrics, text: &str) -> (Toast, Vec<u8>) {
+        let mut toast = Toast::default();
+        toast.show(text.to_string());
+        let mut out = Vec::new();
+        toast.draw(&mut out, m, ink());
+        (toast, out)
+    }
+
+    /// The rows the popup wrote, as `(row, column, text)`, with the escapes and the
+    /// image payloads taken out. One-based, as the cursor is.
+    fn rows(buf: &[u8]) -> Vec<(u16, u16, String)> {
+        let text = String::from_utf8(buf.to_vec()).unwrap();
+        let mut out: Vec<(u16, u16, String)> = Vec::new();
+        let mut chars = text.chars().peekable();
+        while let Some(c) = chars.next() {
+            match c {
+                '\x1b' => match chars.next() {
+                    // CSI: parameters then a letter, and `H` starts a fresh row.
+                    Some('[') => {
+                        let mut params = String::new();
+                        for c in chars.by_ref() {
+                            if c.is_ascii_alphabetic() {
+                                if c == 'H'
+                                    && let Some((r, col)) = params.split_once(';')
+                                    && let (Ok(r), Ok(col)) = (r.parse::<u16>(), col.parse::<u16>())
+                                {
+                                    out.push((r, col, String::new()));
+                                }
+                                break;
+                            }
+                            params.push(c);
+                        }
+                    }
+                    // APC: an image, terminated by ESC backslash.
+                    Some('_') => {
+                        while let Some(c) = chars.next() {
+                            if c == '\x1b' {
+                                chars.next();
+                                break;
+                            }
+                        }
+                    }
+                    _ => {}
+                },
+                c => {
+                    if let Some(row) = out.last_mut() {
+                        row.2.push(c);
+                    }
+                }
+            }
+        }
+        out.retain(|(.., text)| !text.is_empty());
+        out
+    }
+
+    #[test]
+    fn the_popup_sits_in_the_top_right_with_room_around_it() {
+        let m = metrics(80, 24);
+        let (_, out) = shown(&m, "full refresh requested");
+        let rows = rows(&out);
+
+        // Three rows: a padding row, the message, another padding row. All at the same
+        // column, and none of them on row one or against the right edge.
+        assert_eq!(rows.len(), 3, "expected a padded box: {rows:?}");
+        let width = rows[0].2.chars().count();
+        assert!(
+            rows.iter().all(|(.., text)| text.chars().count() == width),
+            "every row must fill the box, or the backdrop shows through: {rows:?}"
+        );
+        let left = rows[0].1;
+        assert!(rows.iter().all(|(_, col, _)| *col == left));
+        assert_eq!(rows[0].0, MARGIN_Y + 1, "not held off the top");
+        assert_eq!(rows[1].0, MARGIN_Y + 2);
+        assert_eq!(
+            usize::from(left) + width - 1,
+            usize::from(80 - MARGIN_X),
+            "not held off the right edge"
+        );
+
+        // The message is the middle row, indented by the padding on both sides, with the
+        // button out at the end of it.
+        assert!(rows[0].2.trim().is_empty(), "no padding above the message");
+        assert!(rows[2].2.trim().is_empty(), "no padding below the message");
+        assert_eq!(rows[1].2, "  full refresh requested   x  ");
+    }
+
+    #[test]
+    fn the_popup_carries_its_own_backdrop() {
+        // Tiles sit at z=-1: below the text but above the cell background, so no SGR
+        // fill is ever seen behind the glyphs. The backdrop has to be an image of our
+        // own, outranking every tile id -- and the menu's, so a note that arrives with
+        // the menu open is not drawn underneath it.
+        let (_, out) = shown(&metrics(80, 24), "remote clipboard copied");
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains(&format!("i={},", kitty::TOAST_IMAGE_ID)),
+            "the popup must place a backdrop image, not colour its cells"
+        );
+        const { assert!(kitty::TOAST_IMAGE_ID > kitty::MENU_HIGHLIGHT_IMAGE_ID) };
+        assert!(
+            text.contains("z=-1"),
+            "the backdrop shares the tiles' z-index; above it would cover the message"
+        );
+        assert!(
+            text.contains(&bg(ink().paper)) && text.contains(&fg(ink().ink)),
+            "the cells are coloured too, for a terminal with no graphics protocol"
+        );
+        assert!(
+            !text.contains("\x1b[7m"),
+            "reverse video would follow the theme instead of the palette"
+        );
+        // The backdrop goes down before the message that sits on it.
+        let backdrop = text.find("\x1b_Ga=T").expect("no backdrop");
+        assert!(backdrop < text.find("clipboard").expect("no message"));
+    }
+
+    #[test]
+    fn the_popup_wears_whichever_palette_is_in_force() {
+        let m = metrics(80, 24);
+        let mut toast = Toast::default();
+        toast.show("scaling: scaled".into());
+        let mut out = Vec::new();
+        toast.draw(&mut out, &m, Theme::Light.palette());
+        let text = String::from_utf8(out).unwrap();
+        let light = Theme::Light.palette();
+        assert!(text.contains(&bg(light.paper)) && text.contains(&fg(light.ink)));
+        assert!(
+            !text.contains(&bg(Theme::Dark.palette().paper)),
+            "the dark paper has no business in a light session: {text:?}"
+        );
+    }
+
+    #[test]
+    fn a_long_message_is_truncated_rather_than_wrapped() {
+        let m = metrics(30, 24);
+        let (_, out) = shown(&m, "a message far longer than thirty columns of terminal");
+        let rows = rows(&out);
+        assert_eq!(rows.len(), 3, "one line, whatever the length: {rows:?}");
+        for (.., text) in &rows {
+            assert_eq!(
+                text.chars().count(),
+                usize::from(30 - MARGIN_X * 2),
+                "the box must stop at the margin: {rows:?}"
+            );
+        }
+        assert_eq!(
+            rows[1].2, "  a message far long   x  ",
+            "the message is what gives way, never the button"
+        );
+    }
+
+    #[test]
+    fn the_button_is_where_the_click_it_answers_lands() {
+        // 80 columns, a margin of two and a box as wide as its message and chrome: the
+        // brackets end two columns in from the right edge of the screen.
+        let m = metrics(80, 24);
+        let (toast, _) = shown(&m, "full refresh requested");
+        let area = area(&m, "full refresh requested").expect("no box");
+        let button = close_at(area);
+        assert_eq!(
+            button.y,
+            area.y + PAD_Y,
+            "the button is on the message's row"
+        );
+        assert_eq!(
+            button.x + button.width,
+            80 - MARGIN_X - PAD_X,
+            "the button is inside the padding, not against the edge"
+        );
+
+        // Every cell of it, and nothing more: what a click acts on is exactly what the
+        // brackets are drawn around, which is what the brackets are for.
+        for x in button.x..button.right() {
+            assert!(toast.on_close(&m, x, button.y), "cell {x} of the button");
+        }
+        assert!(
+            !toast.on_close(&m, button.x - 1, button.y),
+            "the gap in front of it: whitespace, and not the button"
+        );
+        assert!(
+            !toast.on_close(&m, button.right(), button.y),
+            "the padding behind it"
+        );
+        assert!(!toast.on_close(&m, area.x + PAD_X, button.y), "the message");
+        assert!(
+            !toast.on_close(&m, button.x, area.y) && !toast.on_close(&m, button.x, area.y + 2),
+            "the padding rows above and below it"
+        );
+        assert!(
+            !toast.on_close(&m, button.right() + PAD_X, button.y),
+            "the remote screen past the right edge of the box"
+        );
+
+        // Nothing showing and nothing that fits are both nothing to click on.
+        assert!(!Toast::default().on_close(&m, button.x, button.y));
+        let (narrow, _) = shown(&metrics(12, 24), "full refresh requested");
+        assert!(!narrow.on_close(&metrics(12, 24), 7, 2));
+    }
+
+    #[test]
+    fn the_button_lights_up_under_the_pointer() {
+        // Grey to the accent, and that is the whole of it: the same lift the menu's title
+        // gives the same button, which the palette defines for both of them.
+        let m = metrics(80, 24);
+        let ink = ink();
+        let (mut toast, out) = shown(&m, "remote clipboard copied");
+        let quiet = String::from_utf8(out).unwrap();
+        assert!(
+            inked(&quiet, ink.muted).contains(CLOSE),
+            "the button should be quiet until it is pointed at: {quiet:?}"
+        );
+
+        toast.set_hover(true);
+        let mut out = Vec::new();
+        toast.draw(&mut out, &m, ink);
+        let lit = String::from_utf8(out).unwrap();
+        assert!(
+            inked(&lit, ink.accent).contains(CLOSE),
+            "expected the accent on the button: {lit:?}"
+        );
+        assert!(
+            !lit.contains(&fg(ink.muted)),
+            "and the quiet ink was the button's alone: {lit:?}"
+        );
+
+        // Nothing else changes. A ground behind it would have to be an image out here,
+        // being invisible as a cell colour, and a rule under it would be a second mark
+        // for one thing; the row is the same shape lit or not.
+        assert!(
+            !lit.contains(&bg(ink.hover)) && !lit.contains("\x1b[4m"),
+            "the colour is the whole of the lift: {lit:?}"
+        );
+        let images = |text: &str| text.matches("\x1b_G").count();
+        assert_eq!(
+            images(&lit),
+            images(&quiet),
+            "the lit button placed an image of its own: {lit:?}"
+        );
+        assert_eq!(
+            rows(lit.as_bytes()),
+            rows(quiet.as_bytes()),
+            "only the ink should have changed"
+        );
+    }
+
+    #[test]
+    fn the_button_takes_the_note_off_before_its_linger_is_up() {
+        let m = metrics(80, 24);
+        let (mut toast, _) = shown(&m, "remote clipboard copied");
+        toast.set_hover(true);
+        assert!(toast.dismiss(), "the box was left standing");
+        assert!(!toast.is_live());
+
+        let mut out = Vec::new();
+        toast.clear(&mut out);
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            rows(text.as_bytes())
+                .iter()
+                .all(|(.., t)| t.trim().is_empty())
+        );
+        // The backdrop outranks every tile and would stay on top of them for ever.
+        assert!(dropped(&text, kitty::TOAST_IMAGE_ID));
+
+        // The next note is not lit before the pointer has said so.
+        toast.show("full refresh requested".into());
+        let mut out = Vec::new();
+        toast.draw(&mut out, &m, ink());
+        let text = String::from_utf8(out).unwrap();
+        assert!(inked(&text, ink().muted).contains(CLOSE));
+    }
+
+    #[test]
+    fn a_screen_with_no_room_for_it_gets_no_popup() {
+        // Narrow enough that nothing worth reading would fit, and short enough that
+        // the box would sit on the bar.
+        let (_, out) = shown(&metrics(12, 24), "full refresh requested");
+        assert!(out.is_empty(), "drew a box too narrow to say anything");
+
+        let (_, out) = shown(&metrics(80, 4), "full refresh requested");
+        assert!(out.is_empty(), "drew a box over the status line");
+    }
+
+    #[test]
+    fn a_note_stays_for_its_linger_and_then_comes_off() {
+        let m = metrics(80, 24);
+        let (mut toast, out) = shown(&m, "renegotiating the remote size");
+        assert!(!out.is_empty());
+        assert!(!toast.expire(), "took the note off before its time");
+        assert!(toast.is_live());
+
+        toast.age(LINGER);
+        assert!(toast.expire(), "the note outstayed its linger");
+        assert!(!toast.is_live());
+
+        // Blanked cells and a dropped backdrop: the message is text, which no repaint
+        // of the tiles under it would erase.
+        let mut out = Vec::new();
+        toast.clear(&mut out);
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(
+            rows(text.as_bytes()).len(),
+            3,
+            "every row of the box has to be blanked: {text:?}"
+        );
+        assert!(
+            rows(text.as_bytes())
+                .iter()
+                .all(|(.., t)| t.trim().is_empty())
+        );
+        assert!(
+            text.contains(&format!("i={}", kitty::TOAST_IMAGE_ID)),
+            "the backdrop outranks every tile and would stay on top of them: {text:?}"
+        );
+        assert!(!text.contains("renegotiating"), "redrew what it took off");
+
+        // Nothing more to do once the frame carrying it has gone out.
+        toast.commit();
+        let mut out = Vec::new();
+        toast.clear(&mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn a_dropped_frame_leaves_the_erase_to_the_next_one() {
+        let m = metrics(80, 24);
+        let (mut toast, _) = shown(&m, "renegotiating the remote size");
+        toast.age(LINGER);
+        toast.expire();
+
+        // Written but never submitted, so the cells are still on screen and the second
+        // frame has to carry the same erase.
+        let mut first = Vec::new();
+        toast.clear(&mut first);
+        let mut second = Vec::new();
+        toast.clear(&mut second);
+        assert!(!first.is_empty());
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn a_replaced_note_takes_the_wider_box_off_with_it() {
+        // A shorter message makes a narrower box, so the cells past it would keep the
+        // old backdrop unless they are blanked.
+        let m = metrics(80, 24);
+        let (mut toast, _) = shown(&m, "a good deal longer than the next one");
+        assert!(toast.show("brief".into()), "the old box was left standing");
+
+        let mut out = Vec::new();
+        toast.clear(&mut out);
+        let blanked = rows(&out);
+        assert_eq!(blanked.len(), 3);
+        let width = area(&m, "a good deal longer than the next one")
+            .expect("the first box did not fit")
+            .width;
+        assert!(
+            blanked
+                .iter()
+                .all(|(.., text)| text.chars().count() == usize::from(width)),
+            "the erase has to cover the box that was drawn, not the one replacing it"
+        );
+    }
+
+    #[test]
+    fn a_note_replaced_before_it_was_drawn_leaves_nothing_behind() {
+        let mut toast = Toast::default();
+        toast.show("never drawn".into());
+        assert!(
+            !toast.show("nor this".into()),
+            "nothing reached the screen, so nothing has to be taken off it"
+        );
+        let mut out = Vec::new();
+        toast.clear(&mut out);
+        assert!(out.is_empty());
+    }
+}

--- a/tests/input.rs
+++ b/tests/input.rs
@@ -87,7 +87,8 @@ fn input_reaches_the_server_with_pixel_exact_coordinates() {
 #[test]
 fn the_command_menu_holds_the_focus_until_escape() {
     // The menu has the focus while it is up: a key neither dismisses it nor reaches
-    // the remote, and escape -- which is what the title offers -- is the way out.
+    // the remote, and escape is the way out -- as is the [x] on the title, and the
+    // toggle at the top of the box.
     let (server, mut term) = start(Resize::Accept, (1024, 768));
     assert_pixel_exact(&term, Duration::from_secs(10));
 
@@ -227,6 +228,131 @@ fn clicking_a_scaling_option_selects_that_one() {
             ))
             .is_none(),
         "the click was forwarded to the server as well"
+    );
+
+    quit(&mut term);
+    term.wait(Duration::from_secs(10));
+}
+
+#[test]
+fn clicking_the_close_button_puts_the_notification_away() {
+    // The popup's `[x]` is the one target outside the menu. A click on it has to take
+    // the box off the screen before its linger is up -- and take it off properly, the
+    // message being text that no repaint of the tiles under it would erase.
+    let (server, mut term) = start(Resize::Accept, (1024, 768));
+    assert_drew(&term, Duration::from_secs(10));
+
+    // Ctrl+A then f asks for a full refresh, which is the shortest way to a note.
+    term.send(&[0x01]);
+    std::thread::sleep(Duration::from_millis(50));
+    term.send(b"f");
+    assert!(
+        term.wait_for(b"full refresh requested", Duration::from_secs(10)),
+        "the notification never appeared: {}",
+        tail(&term.output())
+    );
+
+    // Where the button is. The message is 22 columns and the box adds eight -- three of
+    // gap, one for the `x`, two of padding either side -- so it is 30 wide, held two
+    // columns off the right of 200 and one row down. That puts the `x` at cell 195,2,
+    // which in 8x17 cells is pixel 1560,34; mouse reports are one-based.
+    //
+    // Checked rather than assumed, because a click aimed at a box that has moved would
+    // fail somewhere far less obvious than here.
+    let out = term.output();
+    let at = find(&out, b"\x1b[3;169H").unwrap_or_else(|| {
+        panic!(
+            "the notification does not start at cell 169,3 any more: {}",
+            tail(&out)
+        )
+    });
+    assert!(
+        contains(
+            &out[at..(at + 120).min(out.len())],
+            b"full refresh requested"
+        ),
+        "cell 169,3 is no longer the message's row, so the click would miss"
+    );
+
+    let mark = out.len();
+    term.send(b"\x1b[<0;1561;35M");
+    term.send(b"\x1b[<0;1561;35m");
+    std::thread::sleep(Duration::from_millis(600));
+
+    let since = term.output()[mark..].to_vec();
+    assert!(
+        contains(&since, b"a=d,d=I,i="),
+        "the popup's backdrop was never deleted, so the box is still there: {}",
+        tail(&since)
+    );
+    assert!(
+        !contains(&since, b"full refresh requested"),
+        "the message is still being redrawn: {}",
+        tail(&since)
+    );
+
+    // And the click went to the popup alone: a press that reached the remote as well
+    // would have landed on whatever the box was covering.
+    assert!(
+        server
+            .wait_for(Duration::from_secs(1), |r| matches!(
+                r,
+                Request::Pointer { buttons: 1, .. }
+            ))
+            .is_none(),
+        "the click was forwarded to the server as well"
+    );
+
+    quit(&mut term);
+    term.wait(Duration::from_secs(10));
+}
+
+#[test]
+fn the_close_button_answers_while_the_menu_is_up() {
+    // Which is most of the time a note is on screen: half the commands that raise one
+    // are reached through the menu, and a click on a menu item leaves the box up. The
+    // popup is drawn over the menu, so it has to be clickable over it too -- otherwise
+    // the menu, which takes the whole pointer while it is up, eats the click.
+    let (_server, mut term) = start(Resize::Accept, (1024, 768));
+    assert_drew(&term, Duration::from_secs(10));
+
+    term.send(&[0x01]);
+    std::thread::sleep(Duration::from_millis(50));
+    term.send(b"p");
+    assert!(
+        term.wait_for(b"Renegotiate the remote size", Duration::from_secs(10)),
+        "the menu never appeared: {}",
+        tail(&term.output())
+    );
+
+    // A local command still works with the menu up, and this one puts a note on screen.
+    term.send(&[0x01]);
+    std::thread::sleep(Duration::from_millis(50));
+    term.send(b"f");
+    assert!(
+        term.wait_for(b"full refresh requested", Duration::from_secs(10)),
+        "the notification never appeared: {}",
+        tail(&term.output())
+    );
+
+    // The button, as in `clicking_the_close_button_puts_the_notification_away`: cell
+    // 195,2 of an 8x17 grid, and mouse reports are one-based.
+    let mark = term.output().len();
+    term.send(b"\x1b[<0;1561;35M");
+    term.send(b"\x1b[<0;1561;35m");
+    std::thread::sleep(Duration::from_millis(600));
+
+    let since = term.output()[mark..].to_vec();
+    assert!(
+        !contains(&since, b"full refresh requested"),
+        "the menu swallowed the click on the popup drawn over it: {}",
+        tail(&since)
+    );
+    // And the menu is still up: the cross closes the note, not the box behind it.
+    assert!(
+        contains(&since, b"Renegotiate the remote size"),
+        "closing the notification put the menu away too: {}",
+        tail(&since)
     );
 
     quit(&mut term);

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -115,7 +115,7 @@ fn a_refused_resize_falls_back_and_says_why() {
     // nowhere -- and the reason has to reach the user.
     assert!(
         term.wait_for(b"prohibited", Duration::from_secs(10)),
-        "the refusal was not explained in the status line: {}",
+        "the refusal was not explained in a notification: {}",
         show(&term.output())
     );
     let output = term.output();


### PR DESCRIPTION
A note used to be tacked onto the status line, where it shared the row with the figures and was the first thing a narrow terminal cut off. It lands in the top-right corner instead, held off it by a margin, and takes itself off again after four seconds. The bar goes back to saying only what is always true of the session.

Everything the box needs the menu needed first, and for the same reasons. Its backdrop is an image, because a cell colour under the remote screen is never seen. Its cells are blanked when it goes, because the message is text and no repaint of the tiles below it can erase that -- and the erase is only forgotten once the frame carrying it has been accepted, so a dropped frame does not leave a box stranded.

The x at the right of the message is the button the menu's title carries now too, where it used to say "esc": one string and one styling, in the palette, because they are the same control and two copies of it would drift into two conventions. It lifts from grey to the accent and does nothing else, which is why the menu no longer bars that row and the popup needs no highlight image of its own.

The popup is offered the pointer before the menu is, because it is drawn over the menu -- half the notes there are arrive from a menu item, and a click on one leaves the box up, so a button the menu could swallow would be a button that did nothing most of the time it was on screen. Only a left press on it is taken: motion and releases go on through, a swallowed release being a button left held down over there.