### PR TITLE
Carry the clipboard in UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@ switchable live with `Ctrl+A` then `n s i 1`. Native asks the server to resize i
 to the terminal so nothing is resampled; the other three cover servers that refuse.
 Arrows pan when the view is cropped.
 
-**A shared clipboard, both directions.** Copy on the remote desktop and paste locally;
-copy locally and paste there. On by default, and `--no-clipboard` leaves your clipboard
-alone in both directions.
+**A shared clipboard, both directions, in UTF-8.** Copy on the remote desktop and paste
+locally; copy locally and paste there. Servers that support the `ExtendedClipboard`
+extension — TigerVNC, RealVNC, noVNC — get the text as UTF-8, so Cyrillic, CJK and emoji
+survive; older servers fall back to the Latin-1 messages RFB started with, which cannot
+carry them. On by default, and `--no-clipboard` leaves your clipboard alone in both
+directions.
 
 **Look without touching.** `--view-only` for the session, `Ctrl+A v` to toggle. It
 stops input reaching the remote and leaves the pointer for the server to draw.
@@ -128,7 +131,10 @@ Everything goes to the remote desktop, so local commands live behind a prefix,
 | `Ctrl+A` | send a literal `Ctrl+A` |
 
 Clipboard works in both directions: paste into the terminal and it reaches the
-remote clipboard; the remote clipboard arrives locally through OSC 52.
+remote clipboard; the remote clipboard arrives locally through OSC 52. With the
+`ExtendedClipboard` extension the text is UTF-8 rather than Latin-1, and each side
+announces a change rather than pushing it — so a local paste crosses the wire when
+something on the remote actually pastes.
 
 ## Authentication
 

--- a/src/rfb/client/clipboard.rs
+++ b/src/rfb/client/clipboard.rs
@@ -1,0 +1,483 @@
+//! The `ExtendedClipboard` pseudo-encoding: the clipboard, in UTF-8.
+//!
+//! Legacy `ClientCutText` and `ServerCutText` carry Latin-1 and nothing else, so
+//! half the world's text cannot survive the trip -- Cyrillic, Greek, CJK and every
+//! emoji come out as question marks. This extension replaces the payload of both
+//! messages with UTF-8, and replaces the eager push with a handshake: the side whose
+//! clipboard changed sends a *notify*, and the other side sends a *request* when it
+//! actually wants the text.
+//!
+//! Both messages keep their type byte. What marks the new format is a *negative*
+//! length, whose magnitude is the byte count that follows -- which is why reading
+//! that length as unsigned is such a destructive bug, and why the decoder in
+//! `messages.rs` reads it as `i32`.
+//!
+//! Only the *text* format is handled here. RTF, HTML, images and files are formats a
+//! terminal has nowhere to put, so they are declined in our capabilities and skipped
+//! if a server sends them anyway.
+//!
+//! See the `ExtendedClipboard` section of the RFB protocol document (TigerVNC's
+//! `rfbproto.rst`), which is where this extension is specified.
+
+use crate::rfb::{MAX_CUT_TEXT, VncError};
+use std::io::{Read, Write};
+
+/// Format and action bits of the flags word.
+pub mod flag {
+    /// Plain text: UTF-8, CRLF line endings, terminated by a null byte.
+    pub const TEXT: u32 = 1 << 0;
+    #[allow(dead_code)]
+    pub const RTF: u32 = 1 << 1;
+    #[allow(dead_code)]
+    pub const HTML: u32 = 1 << 2;
+    #[allow(dead_code)]
+    pub const DIB: u32 = 1 << 3;
+    #[allow(dead_code)]
+    pub const FILES: u32 = 1 << 4;
+    /// "Here is what I am willing to receive." Carries a size per format.
+    pub const CAPS: u32 = 1 << 24;
+    /// "Send me the formats named in these flags."
+    pub const REQUEST: u32 = 1 << 25;
+    /// "Tell me again which formats you have."
+    pub const PEEK: u32 = 1 << 26;
+    /// "My clipboard changed, and holds these formats." Carries no data.
+    pub const NOTIFY: u32 = 1 << 27;
+    /// "Here is the data", zlib compressed.
+    pub const PROVIDE: u32 = 1 << 28;
+    /// Bits 24-31 are actions. Exactly one may be set unless `CAPS` is.
+    pub const ACTION_MASK: u32 = 0xff00_0000;
+}
+
+/// What this client is willing to receive, and what it can do.
+///
+/// Text only, and no `PEEK`: a peek asks for a fresh notify listing what we hold,
+/// and what we hold is whatever the user last pasted -- which the server learns
+/// from the notify we already send.
+pub const OUR_CAPS: u32 = flag::TEXT | flag::CAPS | flag::REQUEST | flag::NOTIFY | flag::PROVIDE;
+
+/// The unsolicited size we advertise for text, in bytes.
+///
+/// Zero, which the spec recommends: it tells the server never to push clipboard data
+/// unasked, but to send a `notify` and wait for a `request`. Anything else leaves it
+/// ambiguous whether an arriving message is a new clipboard or the rest of one that
+/// was too large last time, and a size limit is a poor way to discover that.
+pub const OUR_UNSOLICITED_SIZE: u32 = 0;
+
+/// What the other side will accept, from its `caps` message.
+///
+/// The format and action bits of a `caps` message say what its sender is willing to
+/// *receive*, so every question here is about what we are allowed to send.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Caps {
+    flags: u32,
+    text_size: u32,
+}
+
+impl Caps {
+    /// Whether text can be sent at all. Nothing else a terminal has fits.
+    pub fn takes_text(&self) -> bool {
+        self.flags & flag::TEXT != 0
+    }
+
+    /// Whether a `provide` carrying data is accepted.
+    pub fn takes_provide(&self) -> bool {
+        self.flags & flag::PROVIDE != 0
+    }
+
+    /// Whether a `notify` announcing what we hold is accepted.
+    pub fn takes_notify(&self) -> bool {
+        self.flags & flag::NOTIFY != 0
+    }
+
+    /// The most text, in bytes, that may be sent in a `provide` nobody asked for.
+    ///
+    /// Zero -- which is what the spec recommends both sides advertise -- means every
+    /// transfer has to start with a `notify` and wait to be asked.
+    pub fn unsolicited_text(&self) -> u32 {
+        self.text_size
+    }
+}
+
+/// A decoded extended clipboard message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Message {
+    /// The peer's capabilities, and its unsolicited size limit for text.
+    ///
+    /// A server must send this in answer to a `SetEncodings` naming the
+    /// pseudo-encoding, so receiving it is also how support is confirmed.
+    Caps(Caps),
+    /// The peer wants our clipboard.
+    Request,
+    /// The peer wants a fresh `notify` from us.
+    Peek,
+    /// The peer's clipboard changed. `text` is false when it went empty.
+    Notify { text: bool },
+    /// The peer's clipboard, as text.
+    Provide(String),
+    /// Well formed, but nothing this client acts on: an action we do not implement,
+    /// or data in formats a terminal cannot hold.
+    Ignored,
+}
+
+/// Decode the body of an extended message -- the flags word and everything after it.
+///
+/// The caller has already read the payload and checked its length against
+/// [`MAX_CUT_TEXT`], because a length off the wire is not permission to allocate.
+pub fn decode(payload: &[u8]) -> Result<Message, VncError> {
+    if payload.len() < 4 {
+        return Err(VncError::General(
+            "extended clipboard message shorter than its flags word".into(),
+        ));
+    }
+    let flags = u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
+    let body = &payload[4..];
+
+    // Caps is tested first and on its own: it is the one action that may share the
+    // flags word with format bits that mean something else -- there, they say what
+    // the peer accepts rather than what it is sending.
+    if flags & flag::CAPS != 0 {
+        return decode_caps(flags, body);
+    }
+
+    match flags & flag::ACTION_MASK {
+        flag::REQUEST => Ok(Message::Request),
+        flag::PEEK => Ok(Message::Peek),
+        flag::NOTIFY => Ok(Message::Notify {
+            text: flags & flag::TEXT != 0,
+        }),
+        flag::PROVIDE => decode_provide(flags, body),
+        // Either no action bit or several. Both are out of contract, and neither
+        // leaves anything sensible to do with the payload -- but the stream is still
+        // aligned, since the length told us where this message ends.
+        other => {
+            tracing::debug!("ignoring extended clipboard action {other:#x}");
+            Ok(Message::Ignored)
+        }
+    }
+}
+
+/// `caps`: the flags word, then one `U32` size per format bit set in it.
+fn decode_caps(flags: u32, body: &[u8]) -> Result<Message, VncError> {
+    let mut text_size = 0;
+    let mut rest = body;
+    // Bits 0-15 are the formats, and there is one size for each one set, in
+    // increasing bit order. Text is bit 0, but the walk still has to be a walk: the
+    // sizes for formats we do not want are what tell us where ours is.
+    for bit in 0..16 {
+        let format = 1u32 << bit;
+        if flags & format == 0 {
+            continue;
+        }
+        let (size, tail) = rest.split_at_checked(4).ok_or_else(|| {
+            VncError::General("extended clipboard caps ended mid-size".to_string())
+        })?;
+        if format == flag::TEXT {
+            text_size = u32::from_be_bytes([size[0], size[1], size[2], size[3]]);
+        }
+        rest = tail;
+    }
+    Ok(Message::Caps(Caps { flags, text_size }))
+}
+
+/// `provide`: the flags word, then a zlib stream of `size`-and-`data` pairs, one per
+/// format bit set, in increasing bit order.
+fn decode_provide(flags: u32, body: &[u8]) -> Result<Message, VncError> {
+    if flags & flag::TEXT == 0 {
+        // Some other format, and the pairs we would have to walk past to find text
+        // are inside the compressed stream. Nothing here is worth inflating.
+        tracing::debug!("ignoring extended clipboard provide with formats {flags:#x}");
+        return Ok(Message::Ignored);
+    }
+
+    // Inflate with a ceiling rather than to completion: the compressed payload was
+    // bounded by the message length, but its expansion is not, and zlib will happily
+    // turn a kilobyte into a gigabyte. Text is the only format we asked for, so the
+    // cap that applies to it applies to the whole stream.
+    let mut inflated = Vec::new();
+    let limit = (MAX_CUT_TEXT as u64) + 4;
+    flate2::read::ZlibDecoder::new(body)
+        .take(limit)
+        .read_to_end(&mut inflated)
+        .map_err(|err| VncError::General(format!("extended clipboard was not zlib: {err}")))?;
+    if inflated.len() as u64 > MAX_CUT_TEXT as u64 {
+        return Err(VncError::General(format!(
+            "extended clipboard inflated past the {MAX_CUT_TEXT}-byte cap"
+        )));
+    }
+
+    // Text is bit 0, so it is the first pair in the stream whatever else is set.
+    let (size, data) = inflated.split_at_checked(4).ok_or_else(|| {
+        VncError::General("extended clipboard provide ended mid-size".to_string())
+    })?;
+    let size = u32::from_be_bytes([size[0], size[1], size[2], size[3]]) as usize;
+    if size > data.len() {
+        return Err(VncError::General(format!(
+            "extended clipboard declared {size} bytes of text and sent {}",
+            data.len()
+        )));
+    }
+    Ok(Message::Provide(decode_text(&data[..size])))
+}
+
+/// Turn the wire form of text into what a local clipboard wants.
+///
+/// Three things to undo: the terminating null, which is counted in the size; CRLF
+/// line endings, which the spec mandates and no terminal wants; and the possibility
+/// that the sender's UTF-8 was not.
+fn decode_text(bytes: &[u8]) -> String {
+    let bytes = bytes.strip_suffix(&[0]).unwrap_or(bytes);
+    // Lossy rather than an error: a server that sends one bad byte has still sent a
+    // clipboard the user wants, and refusing the whole transfer -- or worse, the
+    // session -- is a poor trade for a replacement character.
+    String::from_utf8_lossy(bytes)
+        .replace("\r\n", "\n")
+        .replace('\r', "\n")
+}
+
+/// Build a `caps` message body: what we accept, and how much of it unasked.
+pub fn caps() -> Vec<u8> {
+    let mut body = OUR_CAPS.to_be_bytes().to_vec();
+    // One size per format bit in OUR_CAPS, in increasing bit order. Text is the only
+    // one, so this is a single entry.
+    body.extend_from_slice(&OUR_UNSOLICITED_SIZE.to_be_bytes());
+    body
+}
+
+/// Build a `request` message body: send us the text.
+pub fn request() -> Vec<u8> {
+    (flag::REQUEST | flag::TEXT).to_be_bytes().to_vec()
+}
+
+/// Build a `notify` message body: our clipboard changed, and holds text.
+pub fn notify() -> Vec<u8> {
+    (flag::NOTIFY | flag::TEXT).to_be_bytes().to_vec()
+}
+
+/// Build a `provide` message body carrying `text`.
+pub fn provide(text: &str) -> Vec<u8> {
+    // CRLF and a terminating null, both of which the spec asks for, and the null is
+    // counted in the size.
+    let mut payload = text.replace('\n', "\r\n").into_bytes();
+    payload.push(0);
+
+    let mut deflated = Vec::new();
+    {
+        // Level 1: this is text on its way to a clipboard, where the difference
+        // between compression levels is measured in bytes and the time is not.
+        let mut encoder =
+            flate2::write::ZlibEncoder::new(&mut deflated, flate2::Compression::new(1));
+        // A Vec never fails to be written to, and flate2 only surfaces the writer's
+        // errors, so neither of these can fail in practice.
+        let _ = encoder.write_all(&(payload.len() as u32).to_be_bytes());
+        let _ = encoder.write_all(&payload);
+        let _ = encoder.finish();
+    }
+
+    let mut body = (flag::PROVIDE | flag::TEXT).to_be_bytes().to_vec();
+    body.extend_from_slice(&deflated);
+    body
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The wire form of a `provide` body, built the way a server would.
+    fn provided(flags: u32, pairs: &[&[u8]]) -> Vec<u8> {
+        let mut plain = Vec::new();
+        for data in pairs {
+            plain.extend_from_slice(&(data.len() as u32).to_be_bytes());
+            plain.extend_from_slice(data);
+        }
+        let mut deflated = Vec::new();
+        {
+            let mut encoder =
+                flate2::write::ZlibEncoder::new(&mut deflated, flate2::Compression::new(6));
+            encoder.write_all(&plain).unwrap();
+            encoder.finish().unwrap();
+        }
+        let mut body = flags.to_be_bytes().to_vec();
+        body.extend_from_slice(&deflated);
+        body
+    }
+
+    #[test]
+    fn our_caps_body_carries_one_size_per_format_bit() {
+        // Text is the only format we accept, so: the flags word, then one size.
+        assert_eq!(
+            caps(),
+            vec![
+                0x1b, 0x00, 0x00, 0x01, // provide | notify | request | caps | text
+                0x00, 0x00, 0x00, 0x00, // and no unsolicited text, so notify first
+            ]
+        );
+    }
+
+    #[test]
+    fn request_and_notify_are_flags_and_nothing_else() {
+        assert_eq!(request(), vec![0x02, 0x00, 0x00, 0x01]);
+        assert_eq!(notify(), vec![0x08, 0x00, 0x00, 0x01]);
+    }
+
+    #[test]
+    fn cyrillic_survives_a_round_trip() {
+        // The whole point of the extension: Latin-1 cut text turns every one of these
+        // into a question mark.
+        let text = "Привет, мир";
+        let Message::Provide(back) = decode(&provide(text)).unwrap() else {
+            panic!("a provide did not decode as one");
+        };
+        assert_eq!(back, text);
+    }
+
+    #[test]
+    fn a_provide_is_null_terminated_and_crlf_and_the_null_is_counted() {
+        // Both are required by the spec, and the size includes the null.
+        let body = provide("a\nb");
+        let mut inflated = Vec::new();
+        flate2::read::ZlibDecoder::new(&body[4..])
+            .read_to_end(&mut inflated)
+            .unwrap();
+        assert_eq!(inflated, vec![0, 0, 0, 5, b'a', b'\r', b'\n', b'b', 0]);
+    }
+
+    #[test]
+    fn line_endings_come_back_as_newlines() {
+        // CRLF is what the wire uses and a lone CR is what a careless sender uses;
+        // neither belongs in a terminal's clipboard.
+        let body = provided(flag::PROVIDE | flag::TEXT, &[b"one\r\ntwo\rthree\0"]);
+        assert_eq!(
+            decode(&body).unwrap(),
+            Message::Provide("one\ntwo\nthree".to_string())
+        );
+    }
+
+    #[test]
+    fn text_that_is_not_utf8_is_substituted_rather_than_refused() {
+        // A bad byte should cost that byte, not the transfer: the rest of the
+        // clipboard is still what the user asked for.
+        let body = provided(flag::PROVIDE | flag::TEXT, &[b"ok \xff\0"]);
+        assert_eq!(
+            decode(&body).unwrap(),
+            Message::Provide("ok \u{fffd}".to_string())
+        );
+    }
+
+    #[test]
+    fn caps_reports_the_text_size_from_the_right_slot() {
+        // Sizes arrive in increasing bit order with one entry per format bit, so
+        // reading the first word regardless would pick up RTF's size here.
+        let mut body = (flag::CAPS | flag::RTF | flag::TEXT | flag::PROVIDE)
+            .to_be_bytes()
+            .to_vec();
+        body.extend_from_slice(&20_000u32.to_be_bytes()); // text, bit 0
+        body.extend_from_slice(&99u32.to_be_bytes()); // rtf, bit 1
+        let Message::Caps(caps) = decode(&body).unwrap() else {
+            panic!("caps did not decode as caps");
+        };
+        assert_eq!(caps.unsolicited_text(), 20_000);
+        assert!(caps.takes_text() && caps.takes_provide());
+        // Notify was not offered, so announcing a clipboard would be out of contract.
+        assert!(!caps.takes_notify());
+
+        // And with text absent there is no size to find, whatever else is listed.
+        let mut body = (flag::CAPS | flag::RTF).to_be_bytes().to_vec();
+        body.extend_from_slice(&99u32.to_be_bytes());
+        let Message::Caps(caps) = decode(&body).unwrap() else {
+            panic!("caps did not decode as caps");
+        };
+        assert!(!caps.takes_text());
+        assert_eq!(caps.unsolicited_text(), 0);
+    }
+
+    #[test]
+    fn the_actions_that_carry_nothing_decode_from_flags_alone() {
+        assert_eq!(
+            decode(&(flag::REQUEST | flag::TEXT).to_be_bytes()).unwrap(),
+            Message::Request
+        );
+        assert_eq!(decode(&flag::PEEK.to_be_bytes()).unwrap(), Message::Peek);
+        assert_eq!(
+            decode(&(flag::NOTIFY | flag::TEXT).to_be_bytes()).unwrap(),
+            Message::Notify { text: true }
+        );
+        // An empty clipboard is a notify with no format bits, not a missing message.
+        assert_eq!(
+            decode(&flag::NOTIFY.to_be_bytes()).unwrap(),
+            Message::Notify { text: false }
+        );
+    }
+
+    #[test]
+    fn formats_a_terminal_cannot_hold_are_ignored_not_refused() {
+        // An image on the clipboard is not an error, it is just not for us -- and the
+        // length has already told the reader where the message ends, so ignoring it
+        // leaves the stream aligned.
+        let body = provided(flag::PROVIDE | flag::DIB, &[b"\x89PNG"]);
+        assert_eq!(decode(&body).unwrap(), Message::Ignored);
+        // Same for an action we never advertised.
+        assert_eq!(
+            decode(&(1u32 << 29).to_be_bytes()).unwrap(),
+            Message::Ignored
+        );
+        // And for a message with no action bit at all.
+        assert_eq!(decode(&flag::TEXT.to_be_bytes()).unwrap(), Message::Ignored);
+    }
+
+    #[test]
+    fn a_truncated_message_is_refused_rather_than_guessed_at() {
+        assert!(decode(&[0, 0, 0]).is_err());
+        // Caps that promises two sizes and sends one.
+        let mut body = (flag::CAPS | flag::TEXT | flag::RTF).to_be_bytes().to_vec();
+        body.extend_from_slice(&1u32.to_be_bytes());
+        assert!(decode(&body).is_err());
+    }
+
+    #[test]
+    fn a_provide_that_is_not_zlib_is_refused() {
+        let mut body = (flag::PROVIDE | flag::TEXT).to_be_bytes().to_vec();
+        body.extend_from_slice(b"not a zlib stream at all");
+        assert!(decode(&body).is_err());
+    }
+
+    #[test]
+    fn a_provide_longer_than_its_declared_size_is_refused() {
+        // The size is the client's only bound on the text inside the stream, so a
+        // size past the end of the data cannot be trusted to be a rounding error.
+        let mut plain = 64u32.to_be_bytes().to_vec();
+        plain.extend_from_slice(b"four");
+        let mut deflated = Vec::new();
+        {
+            let mut encoder =
+                flate2::write::ZlibEncoder::new(&mut deflated, flate2::Compression::new(6));
+            encoder.write_all(&plain).unwrap();
+            encoder.finish().unwrap();
+        }
+        let mut body = (flag::PROVIDE | flag::TEXT).to_be_bytes().to_vec();
+        body.extend_from_slice(&deflated);
+        assert!(decode(&body).is_err());
+    }
+
+    #[test]
+    fn a_payload_that_inflates_past_the_cap_is_refused_before_it_is_kept() {
+        // A zip bomb is cheap to send and expensive to hold: a megabyte of zeroes
+        // compresses to about a kilobyte, and the message length -- which is all the
+        // reader checked -- says nothing about the size after inflation.
+        let bomb = vec![0u8; MAX_CUT_TEXT + 4096];
+        let mut deflated = Vec::new();
+        {
+            let mut encoder =
+                flate2::write::ZlibEncoder::new(&mut deflated, flate2::Compression::new(9));
+            encoder.write_all(&bomb).unwrap();
+            encoder.finish().unwrap();
+        }
+        assert!(
+            deflated.len() < 8192,
+            "the fixture is meant to be small compressed, was {}",
+            deflated.len()
+        );
+        let mut body = (flag::PROVIDE | flag::TEXT).to_be_bytes().to_vec();
+        body.extend_from_slice(&deflated);
+        assert!(decode(&body).is_err());
+    }
+}

--- a/src/rfb/client/connection.rs
+++ b/src/rfb/client/connection.rs
@@ -15,6 +15,7 @@ use tokio::sync::mpsc::{Receiver, Sender, channel};
 use tokio::task::JoinHandle;
 use tracing::*;
 
+use super::clipboard;
 use super::messages::{ClientMsg, ServerMsg};
 use crate::rfb::{
     PixelFormat, Rect, ResizeStatus, ScreenInfo, ScreenLayout, VncEncoding, VncError, VncEvent,
@@ -124,7 +125,18 @@ impl VncInner {
             .await?;
 
         trace!("client encodings: {:?}", encodings);
+        let extended_clipboard = encodings.contains(&VncEncoding::ExtendedClipboardPseudo);
         send_client_encoding(&mut stream, encodings, quality, compression).await?;
+
+        // A server that understands the extension answers the `SetEncodings` above with
+        // a `caps` message. Ours goes the other way now: text is the only format a
+        // terminal can hold, and the size of zero says we would rather be told the
+        // clipboard changed than handed a copy of every remote selection.
+        if extended_clipboard {
+            ClientMsg::ExtendedCutText(clipboard::caps())
+                .write(&mut stream)
+                .await?;
+        }
 
         // Start with a non-incremental request. Besides fetching the first frame,
         // this is the only way to learn the screen layout: a server supporting
@@ -199,6 +211,11 @@ impl VncInner {
                 ClientMsg::PointerEvent(mouse.position_x, mouse.position_y, mouse.buttons)
             }
             X11Event::CopyText(text) => ClientMsg::ClientCutText(text),
+            X11Event::ClipboardRequest => ClientMsg::ExtendedCutText(clipboard::request()),
+            X11Event::ClipboardNotify => ClientMsg::ExtendedCutText(clipboard::notify()),
+            X11Event::ClipboardProvide(text) => {
+                ClientMsg::ExtendedCutText(clipboard::provide(&text))
+            }
             X11Event::SetDesktopSize {
                 width,
                 height,
@@ -539,11 +556,13 @@ where
                             })
                             .await?;
                         }
-                        // Both are negotiated through SetEncodings and answered with
-                        // messages, never with rectangles. A server sending one here
-                        // is out of contract, and guessing at a length would lose the
-                        // stream.
-                        VncEncoding::FencePseudo | VncEncoding::ContinuousUpdatesPseudo => {
+                        // All three are negotiated through SetEncodings and answered
+                        // with messages, never with rectangles. A server sending one
+                        // here is out of contract, and guessing at a length would lose
+                        // the stream.
+                        VncEncoding::FencePseudo
+                        | VncEncoding::ContinuousUpdatesPseudo
+                        | VncEncoding::ExtendedClipboardPseudo => {
                             return Err(VncError::General(format!(
                                 "server sent {:?} as a rectangle",
                                 rect.encoding
@@ -562,6 +581,25 @@ where
             ServerMsg::ServerCutText(text) => {
                 output_func(VncEvent::Text(text)).await?;
             }
+            ServerMsg::ExtendedClipboard(msg) => match msg {
+                clipboard::Message::Caps(caps) => {
+                    debug!("server extended clipboard: {caps:?}");
+                    output_func(VncEvent::ClipboardCaps(caps)).await?;
+                }
+                clipboard::Message::Notify { text } => {
+                    output_func(VncEvent::ClipboardNotify { text }).await?;
+                }
+                clipboard::Message::Request => {
+                    output_func(VncEvent::ClipboardRequest).await?;
+                }
+                clipboard::Message::Provide(text) => {
+                    output_func(VncEvent::Text(text)).await?;
+                }
+                // A peek asks us to re-announce what we hold. We never advertised the
+                // action, so a server sending one has gone past its own contract, and
+                // the notify it wants would say nothing new.
+                clipboard::Message::Peek | clipboard::Message::Ignored => {}
+            },
             ServerMsg::EndOfContinuousUpdates => {
                 output_func(VncEvent::EndOfContinuousUpdates).await?;
             }
@@ -928,15 +966,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn an_extended_clipboard_message_is_refused_not_misread() {
-        // The length is signed, and negative means the extended clipboard
-        // extension. Read as unsigned it becomes four billion, and the client
-        // spends the rest of the session trying to skip that many bytes.
-        let mut stream: &[u8] = &[
-            3, 0, 0, 0, // ServerCutText
-            0xff, 0xff, 0xff, 0xf8, // length = -8
-            0, 0, 0, 1, // flags
-        ];
+    async fn extended_clipboard_messages_become_events_not_four_billion_bytes() {
+        // The length is signed, and negative means the extended clipboard form. Read
+        // as unsigned it becomes four billion, and the client spends the rest of the
+        // session trying to skip that many bytes.
+        let mut caps = (clipboard::flag::CAPS
+            | clipboard::flag::TEXT
+            | clipboard::flag::PROVIDE
+            | clipboard::flag::REQUEST)
+            .to_be_bytes()
+            .to_vec();
+        caps.extend_from_slice(&1024u32.to_be_bytes());
+
+        let mut bytes = Vec::new();
+        for body in [caps, clipboard::notify()] {
+            bytes.extend_from_slice(&[3, 0, 0, 0]); // ServerCutText
+            bytes.extend_from_slice(&(-(body.len() as i32)).to_be_bytes());
+            bytes.extend_from_slice(&body);
+        }
+
+        let mut stream: &[u8] = &bytes;
         let collected = Rc::new(RefCell::new(Vec::new()));
         let sink = |event: VncEvent| {
             let collected = Rc::clone(&collected);
@@ -946,10 +995,22 @@ mod tests {
             }
         };
         let pf = PixelFormat::bgra();
-        let err = read_loop(&mut stream, &pf, &sink).await.unwrap_err();
+        // Both messages are consumed by their lengths, so the loop runs on until the
+        // stream simply ends.
+        let _ = read_loop(&mut stream, &pf, &sink).await;
+
+        let events = collected.borrow();
         assert!(
-            err.to_string().contains("extended clipboard"),
-            "expected a clear refusal, got {err}"
+            matches!(events.first(), Some(VncEvent::ClipboardCaps(caps))
+                if caps.takes_text() && caps.unsolicited_text() == 1024),
+            "{events:?}"
+        );
+        assert!(
+            matches!(
+                events.get(1),
+                Some(VncEvent::ClipboardNotify { text: true })
+            ),
+            "{events:?}"
         );
     }
 

--- a/src/rfb/client/messages.rs
+++ b/src/rfb/client/messages.rs
@@ -1,3 +1,4 @@
+use super::clipboard;
 use crate::rfb::{MAX_CUT_TEXT, MAX_PAYLOAD, PixelFormat, Rect, ScreenInfo, VncError};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -9,6 +10,10 @@ pub(super) enum ClientMsg {
     KeyEvent(u32, bool),
     PointerEvent(u16, u16, u8),
     ClientCutText(String),
+    /// A `ClientCutText` in the extended form: the body from [`clipboard`], sent
+    /// under a negative length. Only legal once the server has answered our
+    /// `SetEncodings` with a `caps` message.
+    ExtendedCutText(Vec<u8>),
     SetDesktopSize {
         width: u16,
         height: u16,
@@ -172,6 +177,23 @@ impl ClientMsg {
                 let mut payload = vec![6_u8, 0, 0, 0];
                 payload.write_u32(latin1.len() as u32).await?;
                 payload.write_all(&latin1).await?;
+                writer.write_all(&payload).await?;
+                Ok(())
+            }
+            ClientMsg::ExtendedCutText(body) => {
+                // The same message, with the length negated to say the payload is the
+                // extended form rather than Latin-1 text. The magnitude is the whole
+                // body including its flags word, so it is just the body's length.
+                // Negating a length that does not fit in an `i32` would send a
+                // *positive* one and hand the server our zlib stream as if it were
+                // Latin-1 text. Nothing we build comes close, so this is a guard, not
+                // a case to handle.
+                let len = i32::try_from(body.len()).map_err(|_| {
+                    VncError::General(format!("extended clipboard body of {} bytes", body.len()))
+                })?;
+                let mut payload = vec![6_u8, 0, 0, 0];
+                payload.write_i32(-len).await?;
+                payload.write_all(&body).await?;
                 writer.write_all(&payload).await?;
                 Ok(())
             }
@@ -415,6 +437,16 @@ mod client_msg_tests {
     }
 
     #[tokio::test]
+    async fn an_extended_cut_text_goes_out_under_a_negative_length() {
+        // Same message type as the Latin-1 form; the sign of the length is the only
+        // thing telling the server which one it is reading.
+        let bytes = encode(ClientMsg::ExtendedCutText(vec![1, 2, 3, 4, 5])).await;
+        assert_eq!(bytes[..4], [6, 0, 0, 0]);
+        assert_eq!(i32::from_be_bytes(bytes[4..8].try_into().unwrap()), -5);
+        assert_eq!(bytes[8..], [1, 2, 3, 4, 5]);
+    }
+
+    #[tokio::test]
     async fn cut_text_outside_latin1_is_substituted_rather_than_truncated() {
         // Callers substitute before they get here so they can report how much they
         // changed; this is the floor under them. Truncating `c as u8` would send the
@@ -430,6 +462,8 @@ pub(super) enum ServerMsg {
     // SetColorMapEntries,
     Bell,
     ServerCutText(String),
+    /// A `ServerCutText` in the extended form, marked by a negative length.
+    ExtendedClipboard(clipboard::Message),
     /// The server has stopped pushing updates. Also its way of saying the extension
     /// exists, the first time it arrives.
     EndOfContinuousUpdates,
@@ -509,18 +543,13 @@ impl ServerMsg {
 
                 // The length is *signed*: a negative one means the extended
                 // clipboard extension, whose payload is a different shape
-                // entirely. Reading it as unsigned -- which is the obvious
-                // mistake, and the one upstream made -- turns -8 into four
-                // billion and then spends the rest of the session trying to skip
-                // that many bytes. We never request that extension, so a server
-                // sending it is out of contract.
+                // entirely, and whose magnitude is the byte count. Reading it as
+                // unsigned -- which is the obvious mistake, and the one upstream
+                // made -- turns -8 into four billion and then spends the rest of
+                // the session trying to skip that many bytes.
                 let len = reader.read_i32().await?;
                 if len < 0 {
-                    return Err(VncError::General(
-                        "server sent an extended clipboard message, which was never \
-                         requested"
-                            .into(),
-                    ));
+                    return read_extended_clipboard(reader, len.unsigned_abs() as usize).await;
                 }
                 let len = len as usize;
                 if len > MAX_PAYLOAD {
@@ -568,6 +597,48 @@ impl ServerMsg {
             _ => Err(VncError::WrongServerMessage),
         }
     }
+}
+
+/// Read the body of an extended `ServerCutText`, whose length arrived negative.
+///
+/// `len` is that length's magnitude: the whole body, flags word included.
+async fn read_extended_clipboard<S>(reader: &mut S, len: usize) -> Result<ServerMsg, VncError>
+where
+    S: AsyncRead + Unpin,
+{
+    if len < 4 {
+        return Err(VncError::General(format!(
+            "server declared a {len}-byte extended clipboard message, which cannot \
+             hold its own flags"
+        )));
+    }
+    if len > MAX_PAYLOAD {
+        // As with the legacy form: skipping this would mean reading tens of megabytes
+        // to find the next message boundary, so refusing is the kinder answer.
+        return Err(VncError::General(format!(
+            "server declared a {len}-byte extended clipboard payload"
+        )));
+    }
+    // Read it whole -- the length is bounded above and the flags cannot be understood
+    // in pieces -- but do not let a length past the cap turn into an allocation.
+    let keep = len.min(MAX_CUT_TEXT);
+    let mut body = vec![0; keep];
+    reader.read_exact(&mut body).await?;
+    let mut discard = len - keep;
+    let mut sink = [0u8; 4096];
+    while discard > 0 {
+        let n = discard.min(sink.len());
+        reader.read_exact(&mut sink[..n]).await?;
+        discard -= n;
+    }
+    if len > keep {
+        // A clipboard this large is not one a terminal can do anything with, and the
+        // truncated remainder would decode as a corrupt zlib stream. The stream is
+        // aligned again, so the session continues.
+        tracing::warn!("dropping a {len}-byte remote clipboard");
+        return Ok(ServerMsg::ExtendedClipboard(clipboard::Message::Ignored));
+    }
+    Ok(ServerMsg::ExtendedClipboard(clipboard::decode(&body)?))
 }
 
 #[cfg(test)]
@@ -665,22 +736,62 @@ mod server_msg_tests {
     }
 
     #[tokio::test]
-    async fn a_negative_cut_text_length_is_refused_rather_than_read_as_four_billion() {
-        // The length is signed and a negative one announces the extended clipboard
-        // extension, which we never request. Read as unsigned, -8 becomes 4294967288 and
-        // the client spends the rest of the session trying to skip that many bytes.
+    async fn a_negative_cut_text_length_is_the_extension_not_four_billion_bytes() {
+        // The length is signed, and a negative one announces the extended clipboard
+        // form with abs(length) bytes to follow. Read as unsigned, -8 becomes
+        // 4294967288 and the client spends the rest of the session trying to skip that
+        // many bytes.
+        let body = crate::rfb::client::clipboard::notify();
         let mut bytes = vec![3, 0, 0, 0];
-        bytes.extend_from_slice(&(-8i32).to_be_bytes());
+        bytes.extend_from_slice(&(-(body.len() as i32)).to_be_bytes());
+        bytes.extend_from_slice(&body);
+        bytes.extend_from_slice(&NEXT_MESSAGE);
+
+        let (msg, rest) = read(&bytes).await;
+
+        match msg {
+            Ok(ServerMsg::ExtendedClipboard(clipboard::Message::Notify { text })) => assert!(text),
+            other => panic!("{other:?}"),
+        }
+        // And the length is what found the next message, so the stream is still aligned.
+        assert_eq!(rest, NEXT_MESSAGE.to_vec());
+    }
+
+    #[tokio::test]
+    async fn an_extended_message_too_short_for_its_flags_is_refused() {
+        // Four bytes of flags is the minimum any of these can be. Less than that and
+        // there is nothing to dispatch on, so guessing would mean reading into
+        // whatever follows.
+        let mut bytes = vec![3, 0, 0, 0];
+        bytes.extend_from_slice(&(-3i32).to_be_bytes());
+        bytes.extend_from_slice(&[0, 0, 0]);
 
         let (msg, _) = read(&bytes).await;
 
         match msg {
-            Err(VncError::General(text)) => assert!(
-                text.contains("extended clipboard"),
-                "should name the extension: {text}"
-            ),
+            Err(VncError::General(text)) => assert!(text.contains("flags"), "{text}"),
             other => panic!("{other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn an_extended_message_past_the_text_cap_is_dropped_but_still_consumed() {
+        // Too large to be a clipboard a terminal can use, and the part we would keep
+        // is half a zlib stream. Drop it, but read all of it: the session survives a
+        // clipboard it cannot hold.
+        let len = MAX_CUT_TEXT + 32;
+        let mut bytes = vec![3, 0, 0, 0];
+        bytes.extend_from_slice(&(-(len as i32)).to_be_bytes());
+        bytes.extend_from_slice(&vec![0x11; len]);
+        bytes.extend_from_slice(&NEXT_MESSAGE);
+
+        let (msg, rest) = read(&bytes).await;
+
+        assert!(matches!(
+            msg,
+            Ok(ServerMsg::ExtendedClipboard(clipboard::Message::Ignored))
+        ));
+        assert_eq!(rest, NEXT_MESSAGE.to_vec());
     }
 
     #[tokio::test]

--- a/src/rfb/client/messages.rs
+++ b/src/rfb/client/messages.rs
@@ -158,9 +158,20 @@ impl ClientMsg {
                 //   | 4            | U32          | length       |
                 //   | length       | U8 array     | text         |
                 //   +--------------+--------------+--------------+
+                // The text is Latin-1: one byte per character, not UTF-8. Writing
+                // `as_bytes()` sends U+0080..U+00FF as their two-byte UTF-8 form,
+                // which a server reading Latin-1 turns "café" into "cafÃ©" -- and
+                // the length no longer matches the character count either. Anything
+                // above U+00FF cannot be sent at all; the caller substitutes it
+                // already, and doing so here too keeps the wire well formed for
+                // callers that did not rather than truncating into a stray byte.
+                let latin1: Vec<u8> = s
+                    .chars()
+                    .map(|c| if (c as u32) > 0xff { b'?' } else { c as u8 })
+                    .collect();
                 let mut payload = vec![6_u8, 0, 0, 0];
-                payload.write_u32(s.len() as u32).await?;
-                payload.write_all(s.as_bytes()).await?;
+                payload.write_u32(latin1.len() as u32).await?;
+                payload.write_all(&latin1).await?;
                 writer.write_all(&payload).await?;
                 Ok(())
             }
@@ -393,6 +404,23 @@ mod client_msg_tests {
         assert_eq!(up, vec![4, 0, 0, 0, 0x00, 0x00, 0x00, 0x61]);
         let pointer = encode(ClientMsg::PointerEvent(1599, 832, 0b101)).await;
         assert_eq!(pointer, vec![5, 0b101, 0x06, 0x3f, 0x03, 0x40]);
+    }
+
+    #[tokio::test]
+    async fn cut_text_goes_out_as_latin1_not_utf8() {
+        // The e-acute is one byte, 0xe9 -- not the 0xc3 0xa9 that UTF-8 would make of
+        // it, which a server decoding Latin-1 would show as two characters.
+        let bytes = encode(ClientMsg::ClientCutText("caf\u{e9}".into())).await;
+        assert_eq!(bytes, vec![6, 0, 0, 0, 0, 0, 0, 4, b'c', b'a', b'f', 0xe9]);
+    }
+
+    #[tokio::test]
+    async fn cut_text_outside_latin1_is_substituted_rather_than_truncated() {
+        // Callers substitute before they get here so they can report how much they
+        // changed; this is the floor under them. Truncating `c as u8` would send the
+        // coffee cup as 0x15, an unrelated control character.
+        let bytes = encode(ClientMsg::ClientCutText("\u{2615}".into())).await;
+        assert_eq!(bytes, vec![6, 0, 0, 0, 0, 0, 0, 1, b'?']);
     }
 }
 

--- a/src/rfb/client/mod.rs
+++ b/src/rfb/client/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+pub mod clipboard;
 pub mod connection;
 pub mod connector;
 mod messages;

--- a/src/rfb/config.rs
+++ b/src/rfb/config.rs
@@ -28,6 +28,13 @@ pub enum VncEncoding {
     /// The client wants updates pushed rather than requested. Requesting this is how
     /// support is discovered: the server answers with `EndOfContinuousUpdates`.
     ContinuousUpdatesPseudo = -313,
+    /// The client understands the extended `ClientCutText` and `ServerCutText`: UTF-8
+    /// instead of Latin-1, and a notify-then-request handshake instead of a push.
+    /// Requesting this is how support is discovered: the server must answer with a
+    /// `caps` message.
+    ///
+    /// 0xc0a1e5ce, which is negative as an `i32` like every other pseudo-encoding.
+    ExtendedClipboardPseudo = -1_063_131_698,
 }
 
 /// Encoding numbers for the quality and compression hints.
@@ -101,6 +108,7 @@ impl TryFrom<u32> for VncEncoding {
             -261 => Ok(VncEncoding::QemuLedStatePseudo),
             -312 => Ok(VncEncoding::FencePseudo),
             -313 => Ok(VncEncoding::ContinuousUpdatesPseudo),
+            -1_063_131_698 => Ok(VncEncoding::ExtendedClipboardPseudo),
             other => Err(UnknownEncoding(other)),
         }
     }

--- a/src/rfb/event.rs
+++ b/src/rfb/event.rs
@@ -1,4 +1,5 @@
 use crate::rfb::PixelFormat;
+use crate::rfb::client::clipboard::Caps as ClipboardCaps;
 
 type ImageData = Vec<u8>;
 
@@ -166,9 +167,27 @@ pub enum VncEvent {
     FramebufferUpdateEnd,
     /// Just ring a bell.
     Bell,
-    /// The server's clipboard changed. Latin-1 only, per
-    /// [RFC6143](https://www.rfc-editor.org/rfc/rfc6143.html#section-7.6.4).
+    /// The server's clipboard, as text.
+    ///
+    /// From a legacy `ServerCutText`, which is Latin-1 only per
+    /// [RFC6143](https://www.rfc-editor.org/rfc/rfc6143.html#section-7.6.4), or from
+    /// an extended clipboard `provide`, which is UTF-8. By the time it is an event the
+    /// difference is spent: either way this is the remote clipboard.
     Text(String),
+    /// What the server will accept on the extended clipboard.
+    ///
+    /// A server must send this in answer to a `SetEncodings` naming the
+    /// `ExtendedClipboard` pseudo-encoding, so it arriving is how the extension is
+    /// discovered -- and nothing extended may be sent before it does.
+    ClipboardCaps(ClipboardCaps),
+    /// The server's clipboard changed, without saying what is on it.
+    ///
+    /// `text` is false when the remote clipboard went empty. Fetching the text takes a
+    /// [`X11Event::ClipboardRequest`], which is what makes a remote selection cost
+    /// nothing until somebody wants it.
+    ClipboardNotify { text: bool },
+    /// The server wants the clipboard we announced, and is asking for it now.
+    ClipboardRequest,
     /// The server's lock-key state changed.
     ///
     /// Worth having because a remote caps lock that disagrees with the local one
@@ -258,8 +277,21 @@ pub enum X11Event {
     KeyEvent(ClientKeyEvent),
     /// Mouse move, button or scroll.
     PointerEvent(ClientMouseEvent),
-    /// Send text to the server's clipboard. Latin-1 only.
+    /// Send text to the server's clipboard, the legacy way. Latin-1 only.
     CopyText(String),
+    /// Ask the server for the clipboard it announced with
+    /// [`VncEvent::ClipboardNotify`].
+    ClipboardRequest,
+    /// Tell the server we hold text, without sending it.
+    ///
+    /// The server asks for it with [`VncEvent::ClipboardRequest`] if and when
+    /// something on the remote side pastes.
+    ClipboardNotify,
+    /// Send text to the server's clipboard over the extended clipboard, in UTF-8.
+    ///
+    /// Only legal once [`VncEvent::ClipboardCaps`] has said the server takes a
+    /// `provide`, and unsolicited only within the size it advertised.
+    ClipboardProvide(String),
     /// Ask the server to start or stop pushing updates without being asked.
     ///
     /// Only legal once the server has sent `EndOfContinuousUpdates`, which is its

--- a/src/rfb/mod.rs
+++ b/src/rfb/mod.rs
@@ -46,6 +46,7 @@ mod config;
 mod error;
 mod event;
 
+pub use client::clipboard::Caps as ClipboardCaps;
 pub use client::{VncClient, VncConnector};
 pub use config::{PixelFormat, VncEncoding, VncVersion, hint};
 pub use error::VncError;

--- a/src/session.rs
+++ b/src/session.rs
@@ -19,8 +19,8 @@ use crate::cli::{Args, ScaleMode};
 use crate::render::framebuffer::Framebuffer;
 use crate::render::{FrameStats, Layout, Rect, Renderer};
 use crate::rfb::{
-    PixelFormat, ResizeStatus, Screen, ScreenInfo, ScreenLayout, VncClient, VncConnector,
-    VncEncoding, VncError, VncEvent, X11Event,
+    ClipboardCaps, PixelFormat, ResizeStatus, Screen, ScreenInfo, ScreenLayout, VncClient,
+    VncConnector, VncEncoding, VncError, VncEvent, X11Event,
 };
 use crate::term::caps::Caps;
 use crate::term::input::{Command, InputMapper, KeyOutcome, LockState};
@@ -121,15 +121,7 @@ pub async fn run(
                 backoff = RECONNECT_BACKOFF;
                 client
             }
-            None => match try_connect(
-                addr,
-                password.clone(),
-                args.quality,
-                args.compression,
-                !args.view_only,
-            )
-            .await
-            {
+            None => match try_connect(addr, password.clone(), args).await {
                 Ok(client) => {
                     backoff = RECONNECT_BACKOFF;
                     client
@@ -186,27 +178,13 @@ async fn connect(
     password: Option<String>,
     args: &Args,
 ) -> Result<(VncClient, Option<String>)> {
-    match try_connect(
-        addr,
-        password.clone(),
-        args.quality,
-        args.compression,
-        !args.view_only,
-    )
-    .await
-    {
+    match try_connect(addr, password.clone(), args).await {
         Ok(client) => Ok((client, password)),
         Err(VncError::NoPassword) => {
             let password = crate::prompt_password(addr)?;
-            let client = try_connect(
-                addr,
-                Some(password.clone()),
-                args.quality,
-                args.compression,
-                !args.view_only,
-            )
-            .await
-            .map_err(|err| anyhow::anyhow!("{err}"))?;
+            let client = try_connect(addr, Some(password.clone()), args)
+                .await
+                .map_err(|err| anyhow::anyhow!("{err}"))?;
             Ok((client, Some(password)))
         }
         Err(err) => Err(anyhow::anyhow!("{err}")).with_context(|| format!("connecting to {addr}")),
@@ -216,10 +194,12 @@ async fn connect(
 async fn try_connect(
     addr: &str,
     password: Option<String>,
-    quality: Option<u8>,
-    compression: Option<u8>,
-    local_cursor: bool,
+    args: &Args,
 ) -> Result<VncClient, VncError> {
+    // Not in a view-only session: there is no local pointer worth drawing there, and
+    // letting the server composite its own is the only way to see where the real one
+    // is.
+    let local_cursor = !args.view_only;
     let stream = tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(addr))
         .await
         .map_err(|_| VncError::General(format!("timed out connecting to {addr}")))?
@@ -248,16 +228,22 @@ async fn try_connect(
         .add_encoding(VncEncoding::QemuLedStatePseudo)
         // Asking for the cursor shape stops the server drawing the pointer into the
         // framebuffer, which is what lets it move at local speed instead of waiting for
-        // a round trip. Not asked for in a view-only session: there is no local pointer
-        // worth drawing there, and letting the server composite its own is the only way
-        // to see where the real one is.
+        // a round trip.
         .add_encodings(if local_cursor {
             &[VncEncoding::CursorPseudo][..]
         } else {
             &[]
         })
-        .set_quality(quality)
-        .set_compression(compression)
+        // The clipboard in UTF-8 rather than Latin-1, and announced rather than pushed.
+        // Left out entirely with --no-clipboard: the encoding is a standing offer to
+        // exchange clipboards, and a session that wants none should not make it.
+        .add_encodings(if args.no_clipboard {
+            &[]
+        } else {
+            &[VncEncoding::ExtendedClipboardPseudo][..]
+        })
+        .set_quality(args.quality)
+        .set_compression(args.compression)
         .allow_shared(true)
         // BGRA is what an x86 server produces natively, so this is the format
         // that costs neither side a swizzle on the wire. The pack to RGB happens
@@ -319,6 +305,16 @@ struct Session {
 
     view_only: bool,
     no_clipboard: bool,
+    /// What the server accepts on the extended clipboard, once its `caps` message has
+    /// arrived. `None` means the extension is not in play, and the Latin-1 `CutText`
+    /// messages are all there is.
+    clipboard_caps: Option<ClipboardCaps>,
+    /// Text we have told the server we hold and have not been asked for yet.
+    ///
+    /// The extension moves ownership before it moves data: a local paste announces
+    /// itself, and the bytes go over when something on the remote side pastes. Kept
+    /// rather than taken when that happens, because it can be pasted more than once.
+    announced_clipboard: Option<String>,
     /// Which palette the chrome wears. Dark to start, the bar having been that colour
     /// before there was a choice.
     theme: Theme,
@@ -384,6 +380,8 @@ impl Session {
             remote_num_lock: None,
             view_only: args.view_only,
             no_clipboard: args.no_clipboard,
+            clipboard_caps: None,
+            announced_clipboard: None,
             theme: Theme::Dark,
             menu: Menu::new(args.prefix_char()),
             show_menu: false,
@@ -480,6 +478,33 @@ impl Session {
             VncEvent::Text(text) => {
                 if !self.no_clipboard {
                     self.copy_to_local_clipboard(&text);
+                }
+            }
+            VncEvent::ClipboardCaps(caps) => {
+                // The extension is live from here: the clipboard is UTF-8 in both
+                // directions, and a remote selection arrives as an announcement rather
+                // than as a copy of itself.
+                tracing::debug!("extended clipboard negotiated: {caps:?}");
+                self.clipboard_caps = Some(caps);
+            }
+            VncEvent::ClipboardNotify { text } => {
+                // Nothing has been transferred yet -- that is the point of a notify --
+                // so ask for it. With --no-clipboard the extension was never
+                // advertised, so this cannot arrive; the check is belt and braces
+                // around a server that sends one anyway.
+                if text && !self.no_clipboard {
+                    self.send(X11Event::ClipboardRequest).await?;
+                }
+            }
+            VncEvent::ClipboardRequest => {
+                // Something on the remote side pasted, so the text we announced is
+                // wanted now.
+                match self.announced_clipboard.clone() {
+                    Some(text) if !self.view_only && !self.no_clipboard => {
+                        tracing::debug!("sending the announced clipboard, {} bytes", text.len());
+                        self.send(X11Event::ClipboardProvide(text)).await?;
+                    }
+                    _ => tracing::debug!("server asked for a clipboard we never announced"),
                 }
             }
             VncEvent::Bell => {
@@ -851,21 +876,7 @@ impl Session {
             }
             Event::Paste(text) => {
                 if !self.view_only && !self.no_clipboard {
-                    // RFB clipboard traffic is Latin-1 only. Substitute rather than
-                    // drop: deleting characters silently shortens the text and moves
-                    // everything after them, where a question mark leaves the shape
-                    // intact and is visibly a substitution. noVNC does the same.
-                    let dropped = text.chars().filter(|c| (*c as u32) > 0xff).count();
-                    let latin1: String = text
-                        .chars()
-                        .map(|c| if (c as u32) > 0xff { '?' } else { c })
-                        .collect();
-                    self.send(X11Event::CopyText(latin1)).await?;
-                    self.set_note(if dropped > 0 {
-                        format!("pasted; {dropped} character(s) are not Latin-1 and became '?'")
-                    } else {
-                        "pasted to the remote clipboard".into()
-                    });
+                    self.paste_to_remote(text).await?;
                 }
             }
             Event::Resize(cols, rows) => {
@@ -1356,6 +1367,52 @@ impl Session {
         if let Some(pointer) = self.input.release_buttons() {
             let _ = self.client.input(X11Event::PointerEvent(pointer)).await;
         }
+    }
+
+    /// Put locally pasted text on the remote clipboard.
+    ///
+    /// Over the extension the text goes as UTF-8 and arrives whole. Without it the
+    /// payload is Latin-1 and everything outside it has to be substituted, which is
+    /// why a server that negotiated the extension is worth the extra round trip.
+    async fn paste_to_remote(&mut self, text: String) -> Result<()> {
+        if let Some(caps) = self
+            .clipboard_caps
+            .filter(|caps: &ClipboardCaps| caps.takes_text() && caps.takes_provide())
+        {
+            // The size the server's limit applies to is the text as it goes on the
+            // wire: CRLF line endings, and the terminating null that the length counts.
+            let wire_len = text.len() + text.matches('\n').count() + 1;
+            if wire_len as u64 <= u64::from(caps.unsolicited_text()) || !caps.takes_notify() {
+                // Either small enough to push unasked, or a server that offered no way
+                // to announce it, which leaves pushing it the only thing left to try.
+                self.send(X11Event::ClipboardProvide(text)).await?;
+            } else {
+                // Announce it and keep it. The server asks when something over there
+                // pastes, which is the point: a clipboard nobody reads costs one small
+                // message instead of the whole text.
+                self.send(X11Event::ClipboardNotify).await?;
+                self.announced_clipboard = Some(text);
+            }
+            self.set_note("pasted to the remote clipboard".into());
+            return Ok(());
+        }
+
+        // Legacy `ClientCutText` is Latin-1 only. Substitute rather than drop:
+        // deleting characters silently shortens the text and moves everything after
+        // them, where a question mark leaves the shape intact and is visibly a
+        // substitution. noVNC does the same.
+        let dropped = text.chars().filter(|c| (*c as u32) > 0xff).count();
+        let latin1: String = text
+            .chars()
+            .map(|c| if (c as u32) > 0xff { '?' } else { c })
+            .collect();
+        self.send(X11Event::CopyText(latin1)).await?;
+        self.set_note(if dropped > 0 {
+            format!("pasted; {dropped} character(s) are not Latin-1 and became '?'")
+        } else {
+            "pasted to the remote clipboard".into()
+        });
+        Ok(())
     }
 
     /// Put the server's clipboard on the local one, with OSC 52.

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -32,6 +32,12 @@ pub enum Resize {
 }
 
 /// What the client asked for.
+///
+/// The `Clipboard*` variants are named for the extended clipboard actions they carry,
+/// which is worth the repetition in `ClipboardRequest`: the protocol calls it a
+/// request, and calling it anything else here would only obscure which message a
+/// failing test was waiting for.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Request {
     SetPixelFormat,
@@ -49,6 +55,18 @@ pub enum Request {
         buttons: u8,
     },
     CutText(String),
+    /// The client's extended clipboard capabilities, and the size of text it will
+    /// take without asking.
+    ClipboardCaps {
+        flags: u32,
+        text_size: u32,
+    },
+    /// The client holds text and is not sending it yet.
+    ClipboardNotify,
+    /// The client wants the clipboard the server announced.
+    ClipboardRequest,
+    /// The client's clipboard, in UTF-8, out of the zlib stream it arrived in.
+    ClipboardProvide(String),
     SetDesktopSize {
         width: u16,
         height: u16,
@@ -78,6 +96,32 @@ pub struct Extensions {
     /// Send a cursor shape, which a server only does once the client has asked for the
     /// Cursor pseudo-encoding.
     pub cursor: bool,
+    /// Answer `SetEncodings` with an extended clipboard `caps` message, which is how a
+    /// server admits to the extension, and hold [`REMOTE_CLIPBOARD`] for a client that
+    /// asks. Only legal if the client requested the pseudo-encoding, which is asserted.
+    pub extended_clipboard: bool,
+    /// Announce that clipboard with a `notify` as soon as the extension is up, the way
+    /// a server does when a selection is made on the remote desktop.
+    pub announce_clipboard: bool,
+}
+
+/// What the fake server has on its clipboard.
+///
+/// Cyrillic on purpose: none of it exists in Latin-1, so the legacy `ServerCutText`
+/// would deliver a row of question marks and only the extension can carry it.
+pub const REMOTE_CLIPBOARD: &str = "Привет, мир";
+
+/// The `ExtendedClipboard` pseudo-encoding, 0xc0a1e5ce as the signed number the wire
+/// carries.
+pub const EXTENDED_CLIPBOARD_ENCODING: i32 = -1_063_131_698;
+
+/// Flag bits of an extended clipboard message.
+mod clip {
+    pub const TEXT: u32 = 1 << 0;
+    pub const CAPS: u32 = 1 << 24;
+    pub const REQUEST: u32 = 1 << 25;
+    pub const NOTIFY: u32 = 1 << 27;
+    pub const PROVIDE: u32 = 1 << 28;
 }
 
 pub struct FakeServer {
@@ -236,6 +280,30 @@ fn serve(
                     );
                     send_cursor(&mut stream)?;
                 }
+                if extensions.extended_clipboard {
+                    assert!(
+                        encodings_seen.contains(&EXTENDED_CLIPBOARD_ENCODING),
+                        "spoke the extended clipboard to a client that never asked for it"
+                    );
+                    // The spec requires this on every SetEncodings naming the encoding,
+                    // and it is how the client learns the extension is available. Zero
+                    // for the size, so the client has to announce before it sends.
+                    let mut caps =
+                        (clip::CAPS | clip::TEXT | clip::REQUEST | clip::NOTIFY | clip::PROVIDE)
+                            .to_be_bytes()
+                            .to_vec();
+                    caps.extend_from_slice(&0u32.to_be_bytes());
+                    send_extended_clipboard(&mut stream, &caps)?;
+
+                    if extensions.announce_clipboard {
+                        // A selection was made over there. Nothing is sent with it:
+                        // that is the difference the extension makes.
+                        send_extended_clipboard(
+                            &mut stream,
+                            &(clip::NOTIFY | clip::TEXT).to_be_bytes(),
+                        )?;
+                    }
+                }
             }
             3 => {
                 let mut rest = [0u8; 9];
@@ -279,16 +347,24 @@ fn serve(
             6 => {
                 let mut head = [0u8; 7];
                 stream.read_exact(&mut head)?;
-                let len = u32::from_be_bytes([head[3], head[4], head[5], head[6]]) as usize;
-                let mut text = vec![0u8; len];
-                stream.read_exact(&mut text)?;
-                // Latin-1, as the protocol says -- one byte per character. Decoding
-                // this as UTF-8 would accept the client sending UTF-8 too, which is
-                // exactly the bug the paste tests are here to catch.
-                record(
-                    &requests,
-                    Request::CutText(text.iter().map(|&b| b as char).collect()),
-                );
+                // Signed: a negative length is the extended clipboard form, and its
+                // magnitude is the byte count.
+                let len = i32::from_be_bytes([head[3], head[4], head[5], head[6]]);
+                if len < 0 {
+                    let mut body = vec![0u8; len.unsigned_abs() as usize];
+                    stream.read_exact(&mut body)?;
+                    handle_extended_clipboard(&mut stream, &body, &requests)?;
+                } else {
+                    let mut text = vec![0u8; len as usize];
+                    stream.read_exact(&mut text)?;
+                    // Latin-1, as the protocol says -- one byte per character. Decoding
+                    // this as UTF-8 would accept the client sending UTF-8 too, which is
+                    // exactly the bug the paste tests are here to catch.
+                    record(
+                        &requests,
+                        Request::CutText(text.iter().map(|&b| b as char).collect()),
+                    );
+                }
             }
             150 => {
                 let mut rest = [0u8; 9];
@@ -430,6 +506,89 @@ fn send_led_state(stream: &mut TcpStream, caps: bool, num: bool) -> std::io::Res
     msg.push(state);
     stream.write_all(&msg)?;
     stream.flush()
+}
+
+/// Write an extended clipboard message: a `ServerCutText` under a negative length.
+fn send_extended_clipboard(stream: &mut TcpStream, body: &[u8]) -> std::io::Result<()> {
+    let mut msg = vec![3u8, 0, 0, 0];
+    msg.extend_from_slice(&(-(body.len() as i32)).to_be_bytes());
+    msg.extend_from_slice(body);
+    stream.write_all(&msg)?;
+    stream.flush()
+}
+
+/// Read one from the client, and answer it the way a server would.
+fn handle_extended_clipboard(
+    stream: &mut TcpStream,
+    body: &[u8],
+    requests: &Arc<Mutex<Vec<Request>>>,
+) -> std::io::Result<()> {
+    assert!(body.len() >= 4, "an extended message with no flags word");
+    let flags = u32::from_be_bytes(body[0..4].try_into().unwrap());
+
+    if flags & clip::CAPS != 0 {
+        // One size per format bit, and text is the first of them.
+        let text_size = if flags & clip::TEXT != 0 && body.len() >= 8 {
+            u32::from_be_bytes(body[4..8].try_into().unwrap())
+        } else {
+            0
+        };
+        record(requests, Request::ClipboardCaps { flags, text_size });
+    } else if flags & clip::NOTIFY != 0 {
+        record(requests, Request::ClipboardNotify);
+        // A real server asks when something on its side pastes. Asking straight away
+        // is the same exchange with the waiting taken out.
+        send_extended_clipboard(stream, &(clip::REQUEST | clip::TEXT).to_be_bytes())?;
+    } else if flags & clip::REQUEST != 0 {
+        record(requests, Request::ClipboardRequest);
+        send_extended_clipboard(stream, &clipboard_provide(REMOTE_CLIPBOARD))?;
+    } else if flags & clip::PROVIDE != 0 {
+        record(
+            requests,
+            Request::ClipboardProvide(read_provided(&body[4..])),
+        );
+    }
+    Ok(())
+}
+
+/// Pull the text out of a `provide` payload: zlib, then a size and that many bytes.
+fn read_provided(deflated: &[u8]) -> String {
+    use std::io::Read as _;
+    let mut inflated = Vec::new();
+    flate2::read::ZlibDecoder::new(deflated)
+        .read_to_end(&mut inflated)
+        .expect("a provide that was not zlib");
+    assert!(inflated.len() >= 4, "a provide with no size");
+    let size = u32::from_be_bytes(inflated[0..4].try_into().unwrap()) as usize;
+    let text = &inflated[4..][..size];
+    // The size counts a terminating null, and the line endings are CRLF.
+    let text = text
+        .strip_suffix(&[0])
+        .expect("a provide with no terminator");
+    String::from_utf8(text.to_vec())
+        .expect("a provide that was not utf-8")
+        .replace("\r\n", "\n")
+}
+
+/// Build a `provide` body carrying `text`, the way a server does.
+fn clipboard_provide(text: &str) -> Vec<u8> {
+    let mut payload = text.replace('\n', "\r\n").into_bytes();
+    payload.push(0);
+
+    let mut deflated = Vec::new();
+    {
+        let mut encoder =
+            flate2::write::ZlibEncoder::new(&mut deflated, flate2::Compression::new(6));
+        encoder
+            .write_all(&(payload.len() as u32).to_be_bytes())
+            .unwrap();
+        encoder.write_all(&payload).unwrap();
+        encoder.finish().unwrap();
+    }
+
+    let mut body = (clip::PROVIDE | clip::TEXT).to_be_bytes().to_vec();
+    body.extend_from_slice(&deflated);
+    body
 }
 
 fn record(requests: &Arc<Mutex<Vec<Request>>>, request: Request) {

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -282,9 +282,12 @@ fn serve(
                 let len = u32::from_be_bytes([head[3], head[4], head[5], head[6]]) as usize;
                 let mut text = vec![0u8; len];
                 stream.read_exact(&mut text)?;
+                // Latin-1, as the protocol says -- one byte per character. Decoding
+                // this as UTF-8 would accept the client sending UTF-8 too, which is
+                // exactly the bug the paste tests are here to catch.
                 record(
                     &requests,
-                    Request::CutText(String::from_utf8_lossy(&text).into_owned()),
+                    Request::CutText(text.iter().map(|&b| b as char).collect()),
                 );
             }
             150 => {

--- a/tests/input.rs
+++ b/tests/input.rs
@@ -11,7 +11,10 @@ mod common;
 
 use std::time::Duration;
 
-use common::server::{Extensions, FakeServer, Request, Resize};
+use base64::Engine as _;
+use common::server::{
+    EXTENDED_CLIPBOARD_ENCODING, Extensions, FakeServer, REMOTE_CLIPBOARD, Request, Resize,
+};
 use common::session::*;
 use common::*;
 
@@ -448,6 +451,143 @@ fn a_pasted_selection_goes_to_the_remote_clipboard() {
         Request::CutText(text) => assert_eq!(text, "hello there"),
         other => panic!("unexpected request {other:?}"),
     }
+
+    quit(&mut term);
+    term.wait(Duration::from_secs(10));
+}
+
+#[test]
+fn the_extended_clipboard_brings_cyrillic_back_from_the_remote() {
+    // The point of the extension. Over legacy cut text this arrives as a row of
+    // question marks, because Latin-1 has nowhere to put a Cyrillic letter.
+    let (server, mut term) = start_with(
+        Extensions {
+            extended_clipboard: true,
+            announce_clipboard: true,
+            ..Default::default()
+        },
+        (800, 600),
+        &["--scale", "fit"],
+    );
+    assert_drew(&term, Duration::from_secs(10));
+
+    // The server announced a clipboard without sending it, so the client has to ask.
+    assert!(
+        server
+            .wait_for(Duration::from_secs(10), |r| matches!(
+                r,
+                Request::ClipboardRequest
+            ))
+            .is_some(),
+        "the client never asked for the clipboard it was told about"
+    );
+
+    // And what came back went to the local clipboard through OSC 52, in UTF-8.
+    let encoded = base64::engine::general_purpose::STANDARD.encode(REMOTE_CLIPBOARD);
+    assert!(
+        term.wait_for(
+            format!("\x1b]52;c;{encoded}").as_bytes(),
+            Duration::from_secs(10)
+        ),
+        "the remote clipboard never reached the local one: {}",
+        tail(&term.output())
+    );
+
+    quit(&mut term);
+    term.wait(Duration::from_secs(10));
+}
+
+#[test]
+fn a_pasted_selection_is_announced_first_and_sent_when_asked() {
+    // With the server advertising a zero unsolicited size -- which is what the spec
+    // recommends and what TigerVNC does -- a paste says "I have text" and the bytes
+    // follow only when something over there asks for them.
+    let (server, mut term) = start_with(
+        Extensions {
+            extended_clipboard: true,
+            ..Default::default()
+        },
+        (800, 600),
+        &["--scale", "fit"],
+    );
+    assert_drew(&term, Duration::from_secs(10));
+
+    // Our own capabilities go out during the handshake, before any of this.
+    let caps = server
+        .wait_for(Duration::from_secs(10), |r| {
+            matches!(r, Request::ClipboardCaps { .. })
+        })
+        .expect("the client never sent its clipboard capabilities");
+    match caps {
+        Request::ClipboardCaps { text_size, .. } => assert_eq!(
+            text_size, 0,
+            "a nonzero size invites the server to push every remote selection"
+        ),
+        other => panic!("unexpected request {other:?}"),
+    }
+
+    term.send("\x1b[200~Привет, мир\x1b[201~".as_bytes());
+
+    assert!(
+        server
+            .wait_for(Duration::from_secs(10), |r| matches!(
+                r,
+                Request::ClipboardNotify
+            ))
+            .is_some(),
+        "the paste was never announced"
+    );
+    // The fake server answers a notify with a request, so the text should follow --
+    // whole, which is the other half of what the extension is for.
+    let provided = server
+        .wait_for(Duration::from_secs(10), |r| {
+            matches!(r, Request::ClipboardProvide(_))
+        })
+        .expect("the announced text never followed");
+    match provided {
+        Request::ClipboardProvide(text) => assert_eq!(text, "Привет, мир"),
+        other => panic!("unexpected request {other:?}"),
+    }
+    // And none of it went out as Latin-1, which is where the question marks came from.
+    assert!(
+        !server
+            .requests()
+            .iter()
+            .any(|r| matches!(r, Request::CutText(_))),
+        "the paste also went out as legacy cut text"
+    );
+
+    quit(&mut term);
+    term.wait(Duration::from_secs(10));
+}
+
+#[test]
+fn no_clipboard_never_offers_the_extension() {
+    // The pseudo-encoding is a standing offer to exchange clipboards. A session that
+    // wants none should not make it, whatever the server would have done with it.
+    let (server, mut term) = start_with(Extensions::default(), (800, 600), &["--no-clipboard"]);
+    assert_drew(&term, Duration::from_secs(10));
+
+    let encodings = server
+        .wait_for(Duration::from_secs(10), |r| {
+            matches!(r, Request::SetEncodings(_))
+        })
+        .expect("no encodings were sent");
+    match encodings {
+        Request::SetEncodings(ids) => assert!(
+            !ids.contains(&EXTENDED_CLIPBOARD_ENCODING),
+            "offered the extended clipboard with --no-clipboard: {ids:?}"
+        ),
+        other => panic!("unexpected request {other:?}"),
+    }
+    // And nothing extended was sent either, capabilities included.
+    assert!(
+        !server
+            .requests()
+            .iter()
+            .any(|r| matches!(r, Request::ClipboardCaps { .. })),
+        "sent clipboard capabilities for an encoding it never asked for"
+    );
 
     quit(&mut term);
     term.wait(Duration::from_secs(10));

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -215,6 +215,46 @@ fn one_client_adopts_a_resize_another_client_asked_for() {
     watcher.wait(Duration::from_secs(15));
 }
 
+/// Fake-server counterpart: `input::a_pasted_selection_is_announced_first_and_sent_when_asked`,
+/// which follows the same exchange through to the data against a server that answers
+/// exactly as written. What only a real server can settle is the part below: that
+/// TigerVNC recognises the pseudo-encoding, answers with capabilities, and accepts what
+/// we send it under a negative length.
+#[test]
+#[ignore = "needs the desktop container: make desktop"]
+fn a_real_server_negotiates_the_extended_clipboard() {
+    // Cyrillic, which does not exist in Latin-1. Without the extension the client would
+    // have had to substitute it and would say so; the plain note means the negotiation
+    // succeeded, since the UTF-8 path is only taken once the server's `caps` message has
+    // arrived.
+    let mut term = start(&["--scale", "fit"]);
+    assert_drew(&term, Duration::from_secs(30));
+
+    let mark = term.output().len();
+    term.send("\x1b[200~Привет, мир\x1b[201~".as_bytes());
+    assert!(
+        term.wait_for(b"pasted to the remote clipboard", Duration::from_secs(10)),
+        "the paste was never acted on: {}",
+        tail(&term.output())
+    );
+    assert!(
+        !contains(&term.output()[mark..], b"not Latin-1"),
+        "fell back to Latin-1, so the extension was not negotiated: {}",
+        tail(&term.output())
+    );
+
+    // And the server was happy with it. A malformed extended message is a protocol
+    // error to TigerVNC, which drops the connection -- so still drawing a second later
+    // is the assertion that our message was well formed.
+    let before = tiles_drawn(&term);
+    std::thread::sleep(Duration::from_secs(1));
+    assert_kept_drawing(&term, before, "announcing the clipboard");
+
+    quit(&mut term);
+    let status = term.wait(Duration::from_secs(15)).expect("did not exit");
+    assert!(status.success(), "exited with {status:?}");
+}
+
 /// No fake-server counterpart: the fake server does not model "only send what changed",
 /// so the black-after-resize bug this covers cannot be reproduced against it.
 #[test]

--- a/tests/updates.rs
+++ b/tests/updates.rs
@@ -11,7 +11,7 @@ mod common;
 
 use std::time::Duration;
 
-use common::server::{Extensions, FakeServer, Request, Resize};
+use common::server::{EXTENDED_CLIPBOARD_ENCODING, Extensions, FakeServer, Request, Resize};
 use common::session::*;
 use common::*;
 
@@ -87,13 +87,19 @@ fn requests_the_encodings_it_can_actually_decode() {
                 "the cursor shape is what makes a local pointer possible: {encodings:?}"
             );
 
+            assert!(
+                encodings.contains(&EXTENDED_CLIPBOARD_ENCODING),
+                "the extended clipboard is what carries anything outside Latin-1: \
+                 {encodings:?}"
+            );
+
             // Anything advertised has to be something we can consume. For a data
             // encoding that means a decoder, because rectangles carry no length and a
-            // surprise would leave the stream unrecoverable. Fence and
-            // ContinuousUpdates are different in kind: they are answered with
-            // messages, never rectangles.
+            // surprise would leave the stream unrecoverable. Fence,
+            // ContinuousUpdates and ExtendedClipboard are different in kind: they are
+            // answered with messages, never rectangles.
             const DECODABLE_RECTS: [i32; 9] = [0, 1, 7, 16, -223, -224, -239, -261, -308];
-            const NEGOTIATION_ONLY: [i32; 2] = [-312, -313];
+            const NEGOTIATION_ONLY: [i32; 3] = [-312, -313, EXTENDED_CLIPBOARD_ENCODING];
             for encoding in &encodings {
                 assert!(
                     DECODABLE_RECTS.contains(encoding) || NEGOTIATION_ONLY.contains(encoding),


### PR DESCRIPTION
RFB's `ClientCutText` and `ServerCutText` are Latin-1, so half the world's text cannot make the trip. Two commits: a wire-format fix for the text Latin-1 *can* carry, and the extension for the text it cannot.

## Send cut text as Latin-1, not UTF-8

`ClientCutText` was writing the string's UTF-8 bytes, so every character in U+0080..U+00FF went out as its two-byte form and a server decoding Latin-1 read `café` as `cafÃ©` — with a length that no longer matched the character count either.

The fake server hid this: it decoded incoming cut text with `from_utf8_lossy`, accepting the same UTF-8 the client was wrongly sending. It now decodes Latin-1, like a real server, so the existing paste test asserts the wire format for real. Confirmed by restoring the old encoding: the new unit test and the existing integration test both fail against it.

## The ExtendedClipboard extension

The `0xc0a1e5ce` pseudo-encoding replaces the payload of both messages with UTF-8, and the eager push with a handshake — whichever side owns the clipboard sends a `notify`, and the other sends a `request` when it actually wants the text. The new format is marked by a **negative** length, which is the case the reader used to refuse outright.

Decisions:

- **Text only.** RTF, HTML, images and files have nowhere to go in a terminal, so they are declined in our capabilities and skipped if a server sends them anyway.
- **Unsolicited size of zero**, which the spec recommends. The server announces that its clipboard changed instead of pushing a copy of every remote selection; the text still reaches the local clipboard automatically, the fetch is just deferred.
- **A local paste is announced too**, so the bytes cross the wire when something on the remote side actually pastes.
- `--no-clipboard` does not advertise the encoding at all, so no capabilities are exchanged in either direction.
- A server without the extension keeps the Latin-1 path, substitution note and all.

## Verification

Both directions against the TigerVNC container, checked outside the client:

- **Remote → local:** a drag-selection on the remote desktop arrives through `notify`, our `request` and a `provide` carrying real UTF-8 (`d0 a0 d0 98 …`), with CRLF converted and the terminating NUL stripped, then out through OSC 52.
- **Local → remote:** a pasted `Привет-из-терминала` reaches a remote application's stdin unmangled once the server asks for it.

Also worth recording, since both cost time to establish: TigerVNC does **not** relay clipboards client to client — a client's announce only reaches the X selection proxy — and an early run that produced `U+FFFD` was the container's `C` locale mangling the text before it ever reached the clipboard.

Tests: 308 unit and 47 integration passing, `cargo fmt` and `clippy --all-targets -D warnings` clean. New coverage: the codec's wire format and its refusals (including a zlib bomb), the notify/request/provide exchange against the fake server, the Cyrillic round trip, and `--no-clipboard` staying silent.

`live::a_real_server_answers_the_latency_probe` fails on this branch and fails identically on a clean `main`, so it is pre-existing and unrelated. The other 13 live tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)