### PR TITLE
Put a protocol-neutral seam between the session and RFB

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
-//! desktui: a VNC client that draws the remote desktop with the Kitty graphics
-//! protocol, one remote pixel per terminal pixel.
+//! desktui: a remote desktop client that draws with the Kitty graphics protocol,
+//! one remote pixel per terminal pixel.
 
 mod app;
 mod cli;
+mod remote;
 mod render;
 mod rfb;
 mod session;
@@ -76,7 +77,17 @@ fn run(args: &Args) -> Result<()> {
         .enable_all()
         .build()
         .context("failed to start the async runtime")?;
-    runtime.block_on(session::run(args, &caps, &guard, &addr, password))
+    let mut vnc = remote::vnc::Vnc::new(
+        addr,
+        password,
+        remote::vnc::Options {
+            quality: args.quality,
+            compression: args.compression,
+            local_cursor: !args.view_only,
+            clipboard: !args.no_clipboard,
+        },
+    );
+    runtime.block_on(session::run(args, &caps, &guard, &mut vnc))
 }
 
 /// A password from the arguments or the environment, if either has one.

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -1,0 +1,318 @@
+//! The seam between a remote desktop and the session that draws it.
+//!
+//! The session below this module knows about framebuffers, damage rectangles and
+//! terminal input. It knows nothing about RFB, and should learn nothing about any
+//! other protocol either: everything wire-shaped lives behind [`Backend`].
+//!
+//! Two rules keep the seam honest.
+//!
+//! **Capabilities are announced, not assumed.** A session starts out believing the
+//! least: that it must ask for every frame, and that latency cannot be measured. A
+//! backend says otherwise with [`Update::Pushing`] and [`Update::LatencyAvailable`]
+//! when it knows -- which for RFB is only after the encodings have been negotiated,
+//! and so cannot be a value read once at connect time.
+//!
+//! **Mechanics stay behind the seam.** Whether frames arrive because the server was
+//! asked, because continuous updates were negotiated, or because the protocol only
+//! ever pushes, is the backend's business. The session is told the one thing it acts
+//! on: whether frames arrive unasked.
+//!
+//! Keys cross the seam as X11 keysyms. That is RFB's own representation, but it is
+//! also the only one that names a *character* rather than a position on a keyboard,
+//! which is what a terminal can actually report -- crossterm gives us `KeyCode`, not
+//! a scancode. A protocol that wants scancodes (RDP does) translates on its own
+//! side, the way FreeRDP and xrdp do.
+
+pub mod vnc;
+
+use anyhow::Result;
+
+/// A rectangle of the remote framebuffer.
+///
+/// 16-bit throughout, which is what every remote desktop protocol carries on the
+/// wire. The renderer widens to 32-bit at the framebuffer boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rect {
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+}
+
+/// The size of the remote desktop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Screen {
+    pub width: u16,
+    pub height: u16,
+}
+
+impl From<(u16, u16)> for Screen {
+    fn from(tuple: (u16, u16)) -> Self {
+        Self {
+            width: tuple.0,
+            height: tuple.1,
+        }
+    }
+}
+
+/// One screen in the remote desktop's layout.
+///
+/// The `id` and any `flags` bits are opaque: they come from the backend and must be
+/// handed back unchanged in an [`Input::Resize`], because the id is how a server
+/// tells a moved screen from a new one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScreenInfo {
+    pub id: u32,
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+    pub flags: u32,
+}
+
+/// The desktop layout, and why it was reported.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScreenLayout {
+    pub screen: Screen,
+    pub screens: Vec<ScreenInfo>,
+    /// Why the layout was sent: 0 the server changed it itself, 1 this client
+    /// asked, 2 another client asked. Unknown values are treated as 0.
+    pub reason: u16,
+    /// Only meaningful when `reason` is 1 or 2.
+    pub status: ResizeStatus,
+}
+
+impl ScreenLayout {
+    /// Did this arrive because we asked for it?
+    pub fn is_reply_to_us(&self) -> bool {
+        self.reason == 1
+    }
+}
+
+/// How a backend answered an [`Input::Resize`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResizeStatus {
+    Success,
+    Prohibited,
+    OutOfResources,
+    InvalidLayout,
+    /// The server does not control the layout directly -- a hypervisor handing
+    /// the request to a guest, say -- and cannot say yet whether it worked. A
+    /// later layout may report success, possibly much later.
+    Forwarded,
+    Unknown(u16),
+}
+
+impl ResizeStatus {
+    /// A short reason, for the status line.
+    pub fn describe(self) -> &'static str {
+        match self {
+            ResizeStatus::Success => "accepted",
+            ResizeStatus::Prohibited => "resize prohibited",
+            ResizeStatus::OutOfResources => "server out of resources",
+            ResizeStatus::InvalidLayout => "layout rejected",
+            ResizeStatus::Forwarded => "request forwarded",
+            ResizeStatus::Unknown(_) => "resize refused",
+        }
+    }
+}
+
+/// A key going down or coming up, named by X11 keysym.
+///
+/// See the module documentation for why a keysym and not a scancode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Key {
+    pub keysym: u32,
+    pub down: bool,
+}
+
+/// Where the pointer is and which buttons are held.
+///
+/// The button bits are RFB's, from RFC 6143 section 7.5.5: left, middle, right,
+/// then the four wheel directions. A backend whose protocol numbers them
+/// differently translates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Pointer {
+    pub x: u16,
+    pub y: u16,
+    pub buttons: u8,
+}
+
+/// Something that happened on the remote desktop.
+#[derive(Debug, Clone)]
+pub enum Update {
+    /// The remote framebuffer is now this size.
+    Resolution(Screen),
+    /// Pixel data for a rectangle, four bytes per pixel in BGRA order.
+    Bgra(Rect, Vec<u8>),
+    /// Pixel data for a rectangle, as a JPEG. The rectangle's position is
+    /// authoritative; its size is whatever the JPEG says.
+    Jpeg(Rect, Vec<u8>),
+    /// Copy a rectangle of the framebuffer from `from` to `dst`.
+    Copy { dst: Rect, from: (u16, u16) },
+    /// Every rectangle of one update has been consumed.
+    ///
+    /// This is what lets the session pace requests instead of firing them on a
+    /// timer, and where it measures the round trip when it is the one asking.
+    FrameEnd,
+    /// The desktop layout. Receiving one at all means resizing can be asked for.
+    Layout(ScreenLayout),
+    /// A new pointer shape. `bgra` is `size.0 * size.1` pixels.
+    Cursor {
+        size: (u16, u16),
+        hotspot: (u16, u16),
+        bgra: Vec<u8>,
+    },
+    /// The remote clipboard changed.
+    Clipboard(String),
+    /// Whether text sent with [`Input::Clipboard`] survives intact.
+    ///
+    /// `true` means the remote can only carry Latin-1, so anything outside it will be
+    /// substituted and the user should be told. A session assumes `true` until a
+    /// backend says otherwise, because for RFB the answer takes a negotiation and
+    /// being wrong the other way loses characters silently.
+    ClipboardLossy(bool),
+    /// The remote lock-key state, which is worth having because a remote caps lock
+    /// that disagrees with the local one makes every keystroke come out in the
+    /// wrong case.
+    LockKeys { num: bool, caps: bool },
+    /// Frames now arrive without being asked for (`true`), or have stopped doing so
+    /// (`false`). A session starts out assuming `false`.
+    ///
+    /// A backend that only ever pushes says `true` once, before anything else.
+    Pushing(bool),
+    /// A round trip can be measured from now on, with [`Input::ProbeLatency`].
+    LatencyAvailable,
+    /// The round trip asked for by [`Input::ProbeLatency`] came back.
+    LatencyProbe,
+    /// Ring a bell.
+    Bell,
+    /// The connection failed. Terminal: no further updates will arrive.
+    Error(String),
+}
+
+/// Something to ask the remote desktop for.
+#[derive(Debug, Clone)]
+pub enum Input {
+    /// Ask for a frame. `incremental` asks only for what changed; a full request
+    /// is also what makes a backend report its layout.
+    ///
+    /// Ignored by a backend that pushes frames unasked.
+    Refresh {
+        incremental: bool,
+    },
+    Key(Key),
+    Pointer(Pointer),
+    /// Put text on the remote clipboard.
+    ///
+    /// The backend chooses how: the text may go now, or be announced and sent when
+    /// something on the remote side pastes. Text outside Latin-1 is coerced by a
+    /// backend that cannot carry it, which is what [`Update::ClipboardLossy`] warns
+    /// about beforehand.
+    Clipboard(String),
+    /// Ask for a round trip to be measured, answered with [`Update::LatencyProbe`].
+    ///
+    /// Only sent after [`Update::LatencyAvailable`].
+    ProbeLatency,
+    /// Ask the remote desktop to change size.
+    ///
+    /// Only sent after an [`Update::Layout`], and the screen ids and flag bits from
+    /// that layout have to be carried over.
+    Resize {
+        width: u16,
+        height: u16,
+        screens: Vec<ScreenInfo>,
+    },
+}
+
+/// A live connection to a remote desktop.
+///
+/// Every method takes `&self`: the session holds one backend and both reads from it
+/// and writes to it, from the same task, without being able to split the borrow.
+///
+/// [`Backend::recv`] is called from a `select!` and so is dropped and re-entered
+/// constantly. It must be cancel-safe: an implementation that has taken an update
+/// off the wire must not await anything before returning it, or the update is lost
+/// the next time a keystroke wins the race.
+///
+/// A backend either asks for the first frame itself while connecting, or announces
+/// [`Update::Pushing(true)`](Update::Pushing) before anything else. Otherwise the
+/// session waits out its watchdog before asking for one.
+pub trait Backend {
+    /// Wait for the next thing to happen on the remote desktop.
+    async fn recv(&self) -> Result<Update>;
+
+    /// Send something to the remote desktop.
+    async fn send(&self, input: Input) -> Result<()>;
+
+    /// The framebuffer size as last reported.
+    async fn resolution(&self) -> (u16, u16);
+
+    /// What to call this desktop in the status line.
+    async fn name(&self) -> String;
+
+    /// Stop, releasing whatever tasks the backend is running.
+    async fn close(&self);
+}
+
+/// Somewhere to connect to, and the credentials for it.
+///
+/// Separate from [`Backend`] because the session reconnects: it needs to be able to
+/// open the connection again, with the password it was given the first time.
+pub trait Connect {
+    type Backend: Backend;
+
+    /// What to call this in messages to the user.
+    fn address(&self) -> &str;
+
+    /// Open a connection.
+    async fn connect(&self) -> Result<Self::Backend, ConnectError>;
+
+    /// Supply the password the remote asked for, for this attempt and every later
+    /// one.
+    fn use_password(&mut self, password: String);
+}
+
+/// Why a connection attempt did not produce a session.
+#[derive(Debug)]
+pub enum ConnectError {
+    /// The remote wants a password and none was supplied. The caller is expected
+    /// to prompt and try again through [`Connect::use_password`].
+    NeedsPassword,
+    Failed(anyhow::Error),
+}
+
+impl std::fmt::Display for ConnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectError::NeedsPassword => write!(f, "a password is required"),
+            ConnectError::Failed(err) => write!(f, "{err:#}"),
+        }
+    }
+}
+
+impl std::error::Error for ConnectError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_refused_resize_names_its_reason() {
+        assert_eq!(ResizeStatus::Prohibited.describe(), "resize prohibited");
+        assert_eq!(ResizeStatus::Unknown(99).describe(), "resize refused");
+    }
+
+    #[test]
+    fn only_reason_one_is_a_reply_to_this_client() {
+        let layout = |reason| ScreenLayout {
+            screen: (100, 100).into(),
+            screens: vec![],
+            reason,
+            status: ResizeStatus::Success,
+        };
+        assert!(layout(1).is_reply_to_us());
+        assert!(!layout(0).is_reply_to_us());
+        assert!(!layout(2).is_reply_to_us());
+    }
+}

--- a/src/remote/vnc.rs
+++ b/src/remote/vnc.rs
@@ -1,0 +1,770 @@
+//! The RFB backend.
+//!
+//! Everything RFB-shaped that the session used to carry is here: which encodings to
+//! negotiate, the fence flags behind a latency probe, and the continuous-updates
+//! dance. The session is left with the two facts it acts on -- whether frames arrive
+//! unasked, and whether a round trip can be measured -- which arrive as
+//! [`Update::Pushing`] and [`Update::LatencyAvailable`].
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::net::TcpStream;
+
+use super::{Connect, ConnectError, Input, Rect, ResizeStatus, Update};
+use crate::rfb::{
+    ClipboardCaps, PixelFormat, VncClient, VncConnector, VncEncoding, VncError, VncEvent, X11Event,
+};
+
+/// How long to wait for the TCP connection.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Marks a fence as our own latency probe rather than a synchronisation request.
+const RTT_PROBE_MARKER: &[u8] = b"desktui-rtt";
+
+/// What to ask the server for, once connected.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Options {
+    pub quality: Option<u8>,
+    pub compression: Option<u8>,
+    /// Ask the server for the cursor shape, so the pointer can be drawn locally
+    /// instead of waiting for a round trip.
+    pub local_cursor: bool,
+    /// Offer to exchange clipboards at all.
+    pub clipboard: bool,
+}
+
+/// An RFB server, and what it takes to connect to it.
+pub struct Vnc {
+    addr: String,
+    password: Option<String>,
+    opts: Options,
+}
+
+impl Vnc {
+    pub fn new(addr: String, password: Option<String>, opts: Options) -> Self {
+        Self {
+            addr,
+            password,
+            opts,
+        }
+    }
+}
+
+impl Connect for Vnc {
+    type Backend = VncBackend;
+
+    fn address(&self) -> &str {
+        &self.addr
+    }
+
+    fn use_password(&mut self, password: String) {
+        self.password = Some(password);
+    }
+
+    async fn connect(&self) -> Result<Self::Backend, ConnectError> {
+        match self.try_connect().await {
+            Ok(client) => {
+                // Seeded from ServerInit rather than left at zero: the server may
+                // answer SetEncodings before it sends a single rectangle, and
+                // continuous updates enabled for a 0x0 rectangle is a black screen.
+                let size = client.resolution().await;
+                Ok(VncBackend::new(client, size, self.opts))
+            }
+            Err(VncError::NoPassword) => Err(ConnectError::NeedsPassword),
+            Err(err) => Err(ConnectError::Failed(
+                anyhow::anyhow!("{err}").context(format!("connecting to {}", self.addr)),
+            )),
+        }
+    }
+}
+
+impl Vnc {
+    async fn try_connect(&self) -> Result<VncClient, VncError> {
+        let stream = tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(&self.addr))
+            .await
+            .map_err(|_| VncError::General(format!("timed out connecting to {}", self.addr)))?
+            .map_err(VncError::IoError)?;
+        // Input latency is the whole point; do not let Nagle sit on a click.
+        stream.set_nodelay(true).map_err(VncError::IoError)?;
+
+        let password = self.password.clone();
+        VncConnector::new(stream)
+            .set_auth_method(async move { password.ok_or(VncError::NoPassword) })
+            // Order is preference order. Tight first: it is what every modern server
+            // does best, and its JPEG rectangles are the cheapest way to move a busy
+            // screen.
+            .add_encoding(VncEncoding::Tight)
+            .add_encoding(VncEncoding::Zrle)
+            .add_encoding(VncEncoding::CopyRect)
+            .add_encoding(VncEncoding::Raw)
+            .add_encoding(VncEncoding::ExtendedDesktopSizePseudo)
+            .add_encoding(VncEncoding::DesktopSizePseudo)
+            .add_encoding(VncEncoding::LastRectPseudo)
+            // Ask the server to push frames rather than answer a request each time, which
+            // saves a round trip per frame; Fence is what makes that safe to negotiate.
+            .add_encoding(VncEncoding::ContinuousUpdatesPseudo)
+            .add_encoding(VncEncoding::FencePseudo)
+            // And to tell us its lock-key state, so a caps lock that disagrees with the
+            // local keyboard can be corrected instead of shouting.
+            .add_encoding(VncEncoding::QemuLedStatePseudo)
+            // Asking for the cursor shape stops the server drawing the pointer into the
+            // framebuffer, which is what lets it move at local speed instead of waiting for
+            // a round trip. Not asked for in a view-only session: there is no local pointer
+            // worth drawing there, and letting the server composite its own is the only way
+            // to see where the real one is.
+            .add_encodings(if self.opts.local_cursor {
+                &[VncEncoding::CursorPseudo][..]
+            } else {
+                &[]
+            })
+            // The clipboard in UTF-8 rather than Latin-1, and announced rather than
+            // pushed. Left out entirely with --no-clipboard: the encoding is a standing
+            // offer to exchange clipboards, and a session that wants none should not
+            // make it.
+            .add_encodings(if self.opts.clipboard {
+                &[VncEncoding::ExtendedClipboardPseudo][..]
+            } else {
+                &[]
+            })
+            .set_quality(self.opts.quality)
+            .set_compression(self.opts.compression)
+            .allow_shared(true)
+            // BGRA is what an x86 server produces natively, so this is the format
+            // that costs neither side a swizzle on the wire. The pack to RGB happens
+            // once per tile at the end of the pipeline.
+            .set_pixel_format(PixelFormat::bgra())
+            .build()?
+            .try_start()
+            .await?
+            .finish()
+    }
+}
+
+/// What the backend has to remember between events.
+#[derive(Default)]
+struct State {
+    /// Replies the protocol owes the server, waiting to go out.
+    ///
+    /// Queued rather than sent on the spot because [`Backend::recv`] is cancelled
+    /// every time a keystroke or a render tick beats it, and awaiting a send after
+    /// an update has been taken off the wire would lose that update. Nothing here
+    /// waits long: the session is back in `recv` within microseconds, and the queue
+    /// is flushed before anything else is read.
+    outbox: VecDeque<X11Event>,
+    /// A fence has been seen, so the server understands them.
+    fence_seen: bool,
+    /// Continuous updates are on, and for which framebuffer size.
+    ///
+    /// The server remembers the rectangle it was told to push and a resize does not
+    /// change its mind, so this has to be said again after one -- the difference
+    /// between a desktop that grows and one that grows a black band down two sides.
+    pushing_for: Option<(u16, u16)>,
+    /// The framebuffer size, tracked so a resize can re-arm the above.
+    ///
+    /// A second copy of what the engine already knows, because deciding to re-arm
+    /// happens inside a lock with nothing to await on. Both are derived the same
+    /// way: a reported resolution, or a layout the server stands behind.
+    size: (u16, u16),
+    /// What the server accepts on the extended clipboard, once its `caps` message has
+    /// arrived. `None` means the extension is not in play and the Latin-1 `CutText`
+    /// messages are all there is.
+    clipboard: Option<ClipboardCaps>,
+    /// Text we have told the server we hold and have not been asked for yet.
+    ///
+    /// The extension moves ownership before it moves data: a local paste announces
+    /// itself, and the bytes go over when something on the remote side pastes. Kept
+    /// rather than taken when that happens, because it can be pasted more than once.
+    announced: Option<String>,
+    /// Whether the session asked for clipboards to be exchanged at all.
+    clipboard_wanted: bool,
+}
+
+/// A live RFB session.
+pub struct VncBackend {
+    client: VncClient,
+    state: Mutex<State>,
+}
+
+impl VncBackend {
+    fn new(client: VncClient, size: (u16, u16), opts: Options) -> Self {
+        Self {
+            client,
+            state: Mutex::new(State {
+                size,
+                clipboard_wanted: opts.clipboard,
+                ..State::default()
+            }),
+        }
+    }
+
+    /// Send whatever the protocol owes the server.
+    ///
+    /// Called before reading, never after: cancellation here costs nothing, because
+    /// an event that fails to go out is still in the queue.
+    async fn flush(&self) -> Result<()> {
+        loop {
+            let Some(event) = self.state.lock().unwrap().outbox.front().cloned() else {
+                return Ok(());
+            };
+            self.client
+                .input(event)
+                .await
+                .map_err(|err| anyhow::anyhow!("{err}"))
+                .context("failed to answer the server")?;
+            self.state.lock().unwrap().outbox.pop_front();
+        }
+    }
+
+    /// Turn one RFB event into an update, queueing whatever reply it obliges.
+    fn translate(&self, event: VncEvent) -> Option<Update> {
+        self.state.lock().unwrap().translate(event)
+    }
+}
+
+impl State {
+    /// Turn one RFB event into an update, queueing whatever reply it obliges.
+    ///
+    /// `None` means the event was pure protocol and the session has no business
+    /// hearing about it.
+    fn translate(&mut self, event: VncEvent) -> Option<Update> {
+        match event {
+            VncEvent::RawImage(rect, data) => Some(Update::Bgra(rect, data)),
+            VncEvent::JpegImage(rect, data) => Some(Update::Jpeg(rect, data)),
+            VncEvent::Copy(dst, src) => Some(Update::Copy {
+                dst,
+                from: (src.x, src.y),
+            }),
+            VncEvent::SetResolution(screen) => {
+                self.adopt_size((screen.width, screen.height));
+                Some(Update::Resolution(screen))
+            }
+            VncEvent::DesktopLayout(layout) => {
+                // A refused reply leaves the dimensions undefined, so only adopt a
+                // size the server actually stands behind.
+                if !layout.is_reply_to_us() || layout.status == ResizeStatus::Success {
+                    self.adopt_size((layout.screen.width, layout.screen.height));
+                }
+                Some(Update::Layout(layout))
+            }
+            VncEvent::FramebufferUpdateEnd => Some(Update::FrameEnd),
+            VncEvent::SetCursor(rect, pixels) => Some(Update::Cursor {
+                size: (rect.width, rect.height),
+                // The rectangle's x and y are the hotspot rather than a position,
+                // which is a trap worth leaving behind the seam.
+                hotspot: (rect.x, rect.y),
+                bgra: pixels,
+            }),
+            VncEvent::Text(text) => Some(Update::Clipboard(text)),
+            VncEvent::ClipboardCaps(caps) => {
+                // The extension is live from here: the clipboard is UTF-8 in both
+                // directions, and a remote selection arrives as an announcement rather
+                // than as a copy of itself. Only worth telling the session if the caps
+                // actually cover text going the other way -- a server that takes none
+                // leaves us on the lossy path regardless.
+                tracing::debug!("extended clipboard negotiated: {caps:?}");
+                self.clipboard = Some(caps);
+                Some(Update::ClipboardLossy(!self.clipboard_is_usable()))
+            }
+            VncEvent::ClipboardNotify { text } => {
+                // Nothing has been transferred yet -- that is the point of a notify --
+                // so ask for it. With the extension never advertised this cannot
+                // arrive; the check is belt and braces around a server that sends one
+                // anyway.
+                if text && self.clipboard_wanted {
+                    self.outbox.push_back(X11Event::ClipboardRequest);
+                }
+                None
+            }
+            VncEvent::ClipboardRequest => {
+                // Something on the remote side pasted, so the text we announced is
+                // wanted now.
+                match self.announced.clone() {
+                    Some(text) if self.clipboard_wanted => {
+                        tracing::debug!("sending the announced clipboard, {} bytes", text.len());
+                        self.outbox.push_back(X11Event::ClipboardProvide(text));
+                    }
+                    _ => tracing::debug!("server asked for a clipboard we never announced"),
+                }
+                None
+            }
+            VncEvent::Bell => Some(Update::Bell),
+            VncEvent::LedState { num, caps, .. } => Some(Update::LockKeys { num, caps }),
+            VncEvent::SetPixelFormat(pf) => {
+                // Nothing above acts on this: the connector pinned the format.
+                tracing::debug!("server pixel format: {pf:?}");
+                None
+            }
+            VncEvent::EndOfContinuousUpdates => {
+                // The first one of these is the server saying the extension exists.
+                // Any later one means it stopped, and asking again is how it restarts.
+                self.pushing_for = None;
+                self.enable_pushing();
+                Some(Update::Pushing(true))
+            }
+            VncEvent::Fence { flags, payload } => {
+                // A fence at all means the server understands them, which is what
+                // makes a latency probe possible.
+                let first = !std::mem::replace(&mut self.fence_seen, true);
+
+                if flags & crate::rfb::fence::REQUEST != 0 {
+                    // A fence with the request bit set has to come back with that bit
+                    // cleared, along with any flag we do not understand. Ours arrive
+                    // in order and are handled one at a time, which is what
+                    // BlockBefore and BlockAfter ask for, so echoing is all there is
+                    // to do.
+                    let echo =
+                        flags & (crate::rfb::fence::BLOCK_BEFORE | crate::rfb::fence::BLOCK_AFTER);
+                    self.outbox.push_back(X11Event::Fence {
+                        flags: echo,
+                        payload,
+                    });
+                    // The session hears about the capability, not the fence.
+                    return first.then_some(Update::LatencyAvailable);
+                }
+
+                if payload == RTT_PROBE_MARKER {
+                    return Some(Update::LatencyProbe);
+                }
+                tracing::debug!("unsolicited fence response, flags {flags:#x}");
+                first.then_some(Update::LatencyAvailable)
+            }
+            VncEvent::Error(err) => Some(Update::Error(err)),
+        }
+    }
+
+    /// Note a new framebuffer size, re-arming continuous updates if they were on.
+    fn adopt_size(&mut self, size: (u16, u16)) {
+        if size == self.size || size.0 == 0 || size.1 == 0 {
+            return;
+        }
+        self.size = size;
+        if self.pushing_for.is_some() {
+            self.pushing_for = None;
+            self.enable_pushing();
+        }
+    }
+
+    /// Does the extension cover text in both directions?
+    ///
+    /// A server may answer the `SetEncodings` and still decline text, or decline to be
+    /// given any, which leaves the legacy Latin-1 message as the only way across.
+    fn clipboard_is_usable(&self) -> bool {
+        self.clipboard
+            .is_some_and(|caps| caps.takes_text() && caps.takes_provide())
+    }
+
+    /// Which message carries locally pasted text, and whether it goes now.
+    ///
+    /// Over the extension the text goes as UTF-8 and arrives whole. Without it the
+    /// payload is Latin-1 and everything outside it has to be substituted, which is
+    /// why a server that negotiated the extension is worth the extra round trip.
+    fn paste(&mut self, text: String) -> X11Event {
+        if let Some(caps) = self.clipboard.filter(|_| self.clipboard_is_usable()) {
+            // The size the server's limit applies to is the text as it goes on the
+            // wire: CRLF line endings, and the terminating null that the length counts.
+            let wire_len = text.len() + text.matches('\n').count() + 1;
+            if wire_len as u64 <= u64::from(caps.unsolicited_text()) || !caps.takes_notify() {
+                // Either small enough to push unasked, or a server that offered no way
+                // to announce it, which leaves pushing it the only thing left to try.
+                return X11Event::ClipboardProvide(text);
+            }
+            // Announce it and keep it. The server asks when something over there
+            // pastes, which is the point: a clipboard nobody reads costs one small
+            // message instead of the whole text.
+            self.announced = Some(text);
+            return X11Event::ClipboardNotify;
+        }
+
+        // Legacy `ClientCutText` is Latin-1 only. Substitute rather than drop:
+        // deleting characters silently shortens the text and moves everything after
+        // them, where a question mark leaves the shape intact and is visibly a
+        // substitution. noVNC does the same. The session has already warned about it,
+        // having been told the clipboard is lossy.
+        X11Event::CopyText(
+            text.chars()
+                .map(|c| if (c as u32) > 0xff { '?' } else { c })
+                .collect(),
+        )
+    }
+
+    /// Ask the server to push updates for the whole framebuffer.
+    fn enable_pushing(&mut self) {
+        if self.pushing_for == Some(self.size) {
+            return;
+        }
+        let (width, height) = self.size;
+        self.outbox.push_back(X11Event::EnableContinuousUpdates {
+            enable: true,
+            rect: Rect {
+                x: 0,
+                y: 0,
+                width,
+                height,
+            },
+        });
+        self.pushing_for = Some(self.size);
+        tracing::debug!("continuous updates enabled for {width}x{height}");
+    }
+}
+
+impl super::Backend for VncBackend {
+    async fn recv(&self) -> Result<Update> {
+        loop {
+            // Before reading, so that a cancellation costs at most a repeated flush.
+            self.flush().await?;
+            let event = self
+                .client
+                .recv_event()
+                .await
+                .map_err(|err| anyhow::anyhow!("{err}"))?;
+            // No await between taking the event and returning it, or a keystroke
+            // winning the race in `select!` would drop a frame.
+            if let Some(update) = self.translate(event) {
+                return Ok(update);
+            }
+        }
+    }
+
+    async fn send(&self, input: Input) -> Result<()> {
+        // Keep our own replies ahead of the session's traffic.
+        self.flush().await?;
+        let event = match input {
+            Input::Refresh { incremental: true } => X11Event::Refresh,
+            Input::Refresh { incremental: false } => X11Event::FullRefresh,
+            Input::Key(key) => X11Event::KeyEvent(key),
+            Input::Pointer(pointer) => X11Event::PointerEvent(pointer),
+            Input::Clipboard(text) => self.state.lock().unwrap().paste(text),
+            // No block flags: the server can answer immediately, which is the point.
+            Input::ProbeLatency => X11Event::Fence {
+                flags: crate::rfb::fence::REQUEST,
+                payload: RTT_PROBE_MARKER.to_vec(),
+            },
+            Input::Resize {
+                width,
+                height,
+                screens,
+            } => X11Event::SetDesktopSize {
+                width,
+                height,
+                screens,
+            },
+        };
+        self.client
+            .input(event)
+            .await
+            .map_err(|err| anyhow::anyhow!("{err}"))
+    }
+
+    async fn resolution(&self) -> (u16, u16) {
+        self.client.resolution().await
+    }
+
+    async fn name(&self) -> String {
+        self.client.name().await
+    }
+
+    async fn close(&self) {
+        self.client.close().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote::{Screen, ScreenLayout};
+
+    /// Every test here drives the state machine, which is the whole of the
+    /// translation and needs no socket behind it.
+    fn state() -> State {
+        State::default()
+    }
+
+    fn request(flags: u32, payload: &[u8]) -> VncEvent {
+        VncEvent::Fence {
+            flags,
+            payload: payload.to_vec(),
+        }
+    }
+
+    #[test]
+    fn a_server_fence_is_echoed_without_the_request_bit() {
+        let mut state = state();
+        let update = state.translate(request(
+            crate::rfb::fence::REQUEST
+                | crate::rfb::fence::BLOCK_BEFORE
+                | crate::rfb::fence::SYNC_NEXT,
+            b"server's own",
+        ));
+        // The session hears that latency can be measured, not about the fence.
+        assert!(matches!(update, Some(Update::LatencyAvailable)));
+
+        match state.outbox.pop_front().unwrap() {
+            X11Event::Fence { flags, payload } => {
+                // Request cleared, BlockBefore kept, SyncNext dropped: we do not
+                // implement it and must not claim to.
+                assert_eq!(flags, crate::rfb::fence::BLOCK_BEFORE);
+                assert_eq!(payload, b"server's own");
+            }
+            other => panic!("expected a fence, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn only_the_first_fence_announces_the_capability() {
+        let mut state = state();
+        assert!(matches!(
+            state.translate(request(crate::rfb::fence::REQUEST, b"")),
+            Some(Update::LatencyAvailable)
+        ));
+        assert!(
+            state
+                .translate(request(crate::rfb::fence::REQUEST, b""))
+                .is_none()
+        );
+        // Both were still echoed.
+        assert_eq!(state.outbox.len(), 2);
+    }
+
+    #[test]
+    fn our_own_probe_coming_back_is_a_measurement() {
+        let mut state = state();
+        // The server proves fences work first, the way a real one does.
+        state.translate(request(crate::rfb::fence::REQUEST, b""));
+        state.outbox.clear();
+
+        let update = state.translate(request(0, RTT_PROBE_MARKER));
+        assert!(matches!(update, Some(Update::LatencyProbe)));
+        // A reply is answered with nothing.
+        assert!(state.outbox.is_empty());
+    }
+
+    #[test]
+    fn end_of_continuous_updates_asks_for_them_again() {
+        let mut state = state();
+        state.size = (800, 600);
+
+        let update = state.translate(VncEvent::EndOfContinuousUpdates);
+        assert!(matches!(update, Some(Update::Pushing(true))));
+        match state.outbox.pop_front().unwrap() {
+            X11Event::EnableContinuousUpdates { enable, rect } => {
+                assert!(enable);
+                assert_eq!((rect.width, rect.height), (800, 600));
+            }
+            other => panic!("expected an enable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_resize_re_arms_continuous_updates_for_the_new_size() {
+        // The bug this guards: the server remembers the rectangle it was told to
+        // push, so without saying it again a desktop that grows gains a black band
+        // down two sides.
+        let mut state = state();
+        state.size = (800, 600);
+        state.translate(VncEvent::EndOfContinuousUpdates);
+        state.outbox.clear();
+
+        state.translate(VncEvent::SetResolution(Screen {
+            width: 1600,
+            height: 900,
+        }));
+        match state.outbox.pop_front().unwrap() {
+            X11Event::EnableContinuousUpdates { rect, .. } => {
+                assert_eq!((rect.width, rect.height), (1600, 900));
+            }
+            other => panic!("expected an enable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pushing_is_enabled_for_the_size_known_at_connect_time() {
+        // The regression this guards: a server may answer SetEncodings before it
+        // sends a single rectangle, so waiting for a resolution event to learn the
+        // size means enabling continuous updates for a 0x0 rectangle -- which is a
+        // black screen. The size comes from ServerInit instead.
+        let mut state = State {
+            size: (1024, 768),
+            ..State::default()
+        };
+        state.translate(VncEvent::EndOfContinuousUpdates);
+        match state.outbox.pop_front().unwrap() {
+            X11Event::EnableContinuousUpdates { rect, .. } => {
+                assert_eq!((rect.width, rect.height), (1024, 768));
+            }
+            other => panic!("expected an enable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_resize_says_nothing_when_updates_were_never_being_pushed() {
+        let mut state = state();
+        state.translate(VncEvent::SetResolution(Screen {
+            width: 1600,
+            height: 900,
+        }));
+        assert!(state.outbox.is_empty());
+    }
+
+    #[test]
+    fn a_refused_resize_does_not_move_the_remembered_size() {
+        let mut state = state();
+        state.size = (800, 600);
+        state.translate(VncEvent::EndOfContinuousUpdates);
+        state.outbox.clear();
+
+        // The spec leaves the dimensions of a refusal undefined, so adopting them
+        // would re-arm pushing for a rectangle that does not exist.
+        state.translate(VncEvent::DesktopLayout(ScreenLayout {
+            screen: (4096, 4096).into(),
+            screens: vec![],
+            reason: 1,
+            status: ResizeStatus::Prohibited,
+        }));
+        assert_eq!(state.size, (800, 600));
+        assert!(state.outbox.is_empty());
+    }
+
+    fn caps_taking(limit: u32) -> ClipboardCaps {
+        ClipboardCaps::taking_text_up_to(limit)
+    }
+
+    #[test]
+    fn negotiated_caps_take_the_clipboard_off_the_lossy_path() {
+        let mut state = State {
+            clipboard_wanted: true,
+            ..State::default()
+        };
+        let update = state.translate(VncEvent::ClipboardCaps(ClipboardCaps::taking_text_up_to(
+            1024,
+        )));
+        assert!(matches!(update, Some(Update::ClipboardLossy(false))));
+    }
+
+    #[test]
+    fn a_paste_the_server_will_take_unasked_goes_straight_over() {
+        let mut state = State {
+            clipboard: Some(caps_taking(1024)),
+            clipboard_wanted: true,
+            ..State::default()
+        };
+        match state.paste("small".into()) {
+            X11Event::ClipboardProvide(text) => assert_eq!(text, "small"),
+            other => panic!("expected a provide, got {other:?}"),
+        }
+        // Nothing is being held for later: it has already gone.
+        assert!(state.announced.is_none());
+    }
+
+    #[test]
+    fn a_paste_over_the_servers_limit_is_announced_and_kept() {
+        // The point of the extension: a clipboard nobody reads costs one small message
+        // instead of the whole text.
+        let mut state = State {
+            clipboard: Some(caps_taking(8)),
+            clipboard_wanted: true,
+            ..State::default()
+        };
+        let long = "x".repeat(100);
+        assert!(matches!(
+            state.paste(long.clone()),
+            X11Event::ClipboardNotify
+        ));
+        assert_eq!(state.announced.as_deref(), Some(long.as_str()));
+
+        // And it goes over when the remote side pastes -- kept, not taken, because it
+        // can be pasted more than once.
+        assert!(state.translate(VncEvent::ClipboardRequest).is_none());
+        match state.outbox.pop_front().unwrap() {
+            X11Event::ClipboardProvide(text) => assert_eq!(text, long),
+            other => panic!("expected a provide, got {other:?}"),
+        }
+        assert!(state.announced.is_some());
+    }
+
+    #[test]
+    fn the_wire_length_counts_line_endings_and_the_terminating_null() {
+        // Ten bytes on the wire: eight characters, one of which becomes CRLF and so
+        // costs an extra byte, plus the null the length counts. A limit of ten takes it
+        // and nine does not.
+        let text = "abc\ndefg";
+        assert_eq!(text.len() + text.matches('\n').count() + 1, 10);
+        let paste = |limit| {
+            State {
+                clipboard: Some(caps_taking(limit)),
+                clipboard_wanted: true,
+                ..State::default()
+            }
+            .paste(text.into())
+        };
+        assert!(matches!(paste(10), X11Event::ClipboardProvide(_)));
+        assert!(matches!(paste(9), X11Event::ClipboardNotify));
+    }
+
+    #[test]
+    fn without_the_extension_a_paste_is_coerced_to_latin1() {
+        // The session has already warned about this, having been told the clipboard is
+        // lossy; coercing here is what stops UTF-8 bytes going out under a Latin-1
+        // message.
+        let mut state = state();
+        match state.paste("piñata — ok".into()) {
+            X11Event::CopyText(text) => {
+                assert_eq!(text, "piñata ? ok");
+                assert!(text.chars().all(|c| (c as u32) <= 0xff));
+            }
+            other => panic!("expected a legacy cut text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_remote_selection_is_fetched_rather_than_waited_for() {
+        let mut state = State {
+            clipboard_wanted: true,
+            ..State::default()
+        };
+        // A notify carries nothing, so the text has to be asked for.
+        assert!(
+            state
+                .translate(VncEvent::ClipboardNotify { text: true })
+                .is_none()
+        );
+        assert!(matches!(
+            state.outbox.pop_front().unwrap(),
+            X11Event::ClipboardRequest
+        ));
+
+        // An empty remote clipboard is not worth a round trip.
+        state.translate(VncEvent::ClipboardNotify { text: false });
+        assert!(state.outbox.is_empty());
+    }
+
+    #[test]
+    fn no_clipboard_ignores_a_notify_the_server_sent_anyway() {
+        let mut state = state();
+        state.translate(VncEvent::ClipboardNotify { text: true });
+        assert!(state.outbox.is_empty());
+    }
+
+    #[test]
+    fn a_cursor_rectangle_becomes_a_size_and_a_hotspot() {
+        let mut state = state();
+        let update = state.translate(VncEvent::SetCursor(
+            Rect {
+                x: 3,
+                y: 4,
+                width: 16,
+                height: 16,
+            },
+            vec![0; 16 * 16 * 4],
+        ));
+        match update {
+            Some(Update::Cursor { size, hotspot, .. }) => {
+                assert_eq!(size, (16, 16));
+                assert_eq!(hotspot, (3, 4));
+            }
+            other => panic!("expected a cursor, got {other:?}"),
+        }
+    }
+}

--- a/src/rfb/client/clipboard.rs
+++ b/src/rfb/client/clipboard.rs
@@ -96,6 +96,17 @@ impl Caps {
     pub fn unsolicited_text(&self) -> u32 {
         self.text_size
     }
+
+    /// Caps as a server that takes everything would report them, with a ceiling on
+    /// unsolicited text. Lets the backend's paste decisions be tested without a
+    /// handshake to build them from.
+    #[cfg(test)]
+    pub fn taking_text_up_to(text_size: u32) -> Self {
+        Self {
+            flags: flag::TEXT | flag::PROVIDE | flag::NOTIFY,
+            text_size,
+        }
+    }
 }
 
 /// A decoded extended clipboard message.

--- a/src/rfb/client/connection.rs
+++ b/src/rfb/client/connection.rs
@@ -17,10 +17,8 @@ use tracing::*;
 
 use super::clipboard;
 use super::messages::{ClientMsg, ServerMsg};
-use crate::rfb::{
-    PixelFormat, Rect, ResizeStatus, ScreenInfo, ScreenLayout, VncEncoding, VncError, VncEvent,
-    X11Event, codec,
-};
+use crate::remote::{Rect, ResizeStatus, ScreenInfo, ScreenLayout};
+use crate::rfb::{PixelFormat, VncEncoding, VncError, VncEvent, X11Event, codec};
 
 const CHANNEL_SIZE: usize = 4096;
 
@@ -206,9 +204,9 @@ impl VncInner {
         let msg = match event {
             X11Event::Refresh => ClientMsg::FramebufferUpdateRequest(self.full_rect(), 1),
             X11Event::FullRefresh => ClientMsg::FramebufferUpdateRequest(self.full_rect(), 0),
-            X11Event::KeyEvent(key) => ClientMsg::KeyEvent(key.keycode, key.down),
+            X11Event::KeyEvent(key) => ClientMsg::KeyEvent(key.keysym, key.down),
             X11Event::PointerEvent(mouse) => {
-                ClientMsg::PointerEvent(mouse.position_x, mouse.position_y, mouse.buttons)
+                ClientMsg::PointerEvent(mouse.x, mouse.y, mouse.buttons)
             }
             X11Event::CopyText(text) => ClientMsg::ClientCutText(text),
             X11Event::ClipboardRequest => ClientMsg::ExtendedCutText(clipboard::request()),
@@ -475,7 +473,7 @@ where
         screen: (rect.width, rect.height).into(),
         screens,
         reason: rect.x,
-        status: ResizeStatus::from(rect.y),
+        status: ResizeStatus::from_wire(rect.y),
     })
 }
 

--- a/src/rfb/client/messages.rs
+++ b/src/rfb/client/messages.rs
@@ -1,5 +1,6 @@
 use super::clipboard;
-use crate::rfb::{MAX_CUT_TEXT, MAX_PAYLOAD, PixelFormat, Rect, ScreenInfo, VncError};
+use crate::remote::{Rect, ScreenInfo};
+use crate::rfb::{MAX_CUT_TEXT, MAX_PAYLOAD, PixelFormat, VncError};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 #[derive(Debug)]

--- a/src/rfb/codec/cursor.rs
+++ b/src/rfb/codec/cursor.rs
@@ -1,4 +1,5 @@
-use crate::rfb::{PixelFormat, Rect, VncError, VncEvent};
+use crate::remote::Rect;
+use crate::rfb::{PixelFormat, VncError, VncEvent};
 use std::future::Future;
 use tokio::io::{AsyncRead, AsyncReadExt};
 

--- a/src/rfb/codec/mod.rs
+++ b/src/rfb/codec/mod.rs
@@ -55,7 +55,8 @@ pub(super) fn palette_entry(
 /// that the pixels are right, and is `#[ignore]`d besides.
 #[cfg(test)]
 pub(super) mod testing {
-    use crate::rfb::{PixelFormat, Rect, VncError, VncEvent};
+    use crate::remote::Rect;
+    use crate::rfb::{PixelFormat, VncError, VncEvent};
     use std::cell::RefCell;
     use std::future::{Ready, ready};
 

--- a/src/rfb/codec/raw.rs
+++ b/src/rfb/codec/raw.rs
@@ -1,4 +1,5 @@
-use crate::rfb::{PixelFormat, Rect, VncError, VncEvent};
+use crate::remote::Rect;
+use crate::rfb::{PixelFormat, VncError, VncEvent};
 use std::future::Future;
 use tokio::io::{AsyncRead, AsyncReadExt};
 

--- a/src/rfb/codec/tight.rs
+++ b/src/rfb/codec/tight.rs
@@ -1,4 +1,5 @@
-use crate::rfb::{PixelFormat, Rect, VncError, VncEvent};
+use crate::remote::Rect;
+use crate::rfb::{PixelFormat, VncError, VncEvent};
 use std::future::Future;
 use std::io::Read;
 use tokio::io::{AsyncRead, AsyncReadExt};

--- a/src/rfb/codec/zrle.rs
+++ b/src/rfb/codec/zrle.rs
@@ -1,4 +1,5 @@
-use crate::rfb::{PixelFormat, Rect, VncError, VncEvent};
+use crate::remote::Rect;
+use crate::rfb::{PixelFormat, VncError, VncEvent};
 use std::future::Future;
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tracing::error;

--- a/src/rfb/event.rs
+++ b/src/rfb/event.rs
@@ -1,49 +1,32 @@
+//! RFB's own event types.
+//!
+//! The geometry these carry belongs to [`crate::remote`]: it is the same on every
+//! wire. What stays here is RFB-shaped -- the wire form of a screen, the events the
+//! decoder produces, and the fence flags.
+
+use crate::remote::{Key, Pointer, Rect, ResizeStatus, Screen, ScreenInfo, ScreenLayout};
 use crate::rfb::PixelFormat;
 use crate::rfb::client::clipboard::Caps as ClipboardCaps;
 
 type ImageData = Vec<u8>;
 
-/// A rect where the image should be updated
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Rect {
-    pub x: u16,
-    pub y: u16,
-    pub width: u16,
-    pub height: u16,
-}
-
-/// Resolution format to resize window
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Screen {
-    pub width: u16,
-    pub height: u16,
-}
-
-impl From<(u16, u16)> for Screen {
-    fn from(tuple: (u16, u16)) -> Self {
-        Self {
-            width: tuple.0,
-            height: tuple.1,
+impl ResizeStatus {
+    /// The status codes an `ExtendedDesktopSize` rectangle carries, which are RFB's
+    /// own numbering and mean nothing on another wire.
+    pub fn from_wire(code: u16) -> Self {
+        match code {
+            0 => ResizeStatus::Success,
+            1 => ResizeStatus::Prohibited,
+            2 => ResizeStatus::OutOfResources,
+            3 => ResizeStatus::InvalidLayout,
+            4 => ResizeStatus::Forwarded,
+            other => ResizeStatus::Unknown(other),
         }
     }
 }
 
-/// One screen in the layout, as carried by `ExtendedDesktopSize` and
-/// `SetDesktopSize`.
-///
-/// The `id` and any unrecognised `flags` bits must be preserved when asking for a
-/// new size: the id is how the server tells a moved screen from a new one.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ScreenInfo {
-    pub id: u32,
-    pub x: u16,
-    pub y: u16,
-    pub width: u16,
-    pub height: u16,
-    pub flags: u32,
-}
-
 impl ScreenInfo {
+    /// Bytes one screen takes in `ExtendedDesktopSize` and `SetDesktopSize`.
     pub const WIRE_LEN: usize = 16;
 
     pub fn encode(&self, out: &mut Vec<u8>) {
@@ -63,66 +46,6 @@ impl ScreenInfo {
             width: u16::from_be_bytes(buf[8..10].try_into().unwrap()),
             height: u16::from_be_bytes(buf[10..12].try_into().unwrap()),
             flags: u32::from_be_bytes(buf[12..16].try_into().unwrap()),
-        }
-    }
-}
-
-/// The desktop layout the server reports, and why.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ScreenLayout {
-    pub screen: Screen,
-    pub screens: Vec<ScreenInfo>,
-    /// Why the layout was sent: 0 the server changed it itself, 1 this client
-    /// asked, 2 another client asked. Unknown values are treated as 0.
-    pub reason: u16,
-    /// Only meaningful when `reason` is 1 or 2.
-    pub status: ResizeStatus,
-}
-
-impl ScreenLayout {
-    /// Did this arrive because we asked for it?
-    pub fn is_reply_to_us(&self) -> bool {
-        self.reason == 1
-    }
-}
-
-/// Status codes a server returns for a `SetDesktopSize` request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ResizeStatus {
-    Success,
-    Prohibited,
-    OutOfResources,
-    InvalidLayout,
-    /// The server does not control the layout directly -- a hypervisor handing
-    /// the request to a guest, say -- and cannot say yet whether it worked. A
-    /// later `ExtendedDesktopSize` may report success, possibly much later.
-    Forwarded,
-    Unknown(u16),
-}
-
-impl From<u16> for ResizeStatus {
-    fn from(code: u16) -> Self {
-        match code {
-            0 => ResizeStatus::Success,
-            1 => ResizeStatus::Prohibited,
-            2 => ResizeStatus::OutOfResources,
-            3 => ResizeStatus::InvalidLayout,
-            4 => ResizeStatus::Forwarded,
-            other => ResizeStatus::Unknown(other),
-        }
-    }
-}
-
-impl ResizeStatus {
-    /// A short reason, for the status line.
-    pub fn describe(self) -> &'static str {
-        match self {
-            ResizeStatus::Success => "accepted",
-            ResizeStatus::Prohibited => "resize prohibited",
-            ResizeStatus::OutOfResources => "server out of resources",
-            ResizeStatus::InvalidLayout => "layout rejected",
-            ResizeStatus::Forwarded => "request forwarded",
-            ResizeStatus::Unknown(_) => "resize refused",
         }
     }
 }
@@ -223,44 +146,6 @@ pub mod fence {
     pub const REQUEST: u32 = 1 << 31;
 }
 
-/// X11 keyboard event to notify the server.
-///
-/// See [RFC6143, section-7.5.4](https://www.rfc-editor.org/rfc/rfc6143.html#section-7.5.4).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ClientKeyEvent {
-    pub keycode: u32,
-    pub down: bool,
-}
-
-impl From<(u32, bool)> for ClientKeyEvent {
-    fn from(tuple: (u32, bool)) -> Self {
-        Self {
-            keycode: tuple.0,
-            down: tuple.1,
-        }
-    }
-}
-
-/// X11 mouse event to notify the server.
-///
-/// See [RFC6143, section-7.5.5](https://www.rfc-editor.org/rfc/rfc6143.html#section-7.5.5).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ClientMouseEvent {
-    pub position_x: u16,
-    pub position_y: u16,
-    pub buttons: u8,
-}
-
-impl From<(u16, u16, u8)> for ClientMouseEvent {
-    fn from(tuple: (u16, u16, u8)) -> Self {
-        Self {
-            position_x: tuple.0,
-            position_y: tuple.1,
-            buttons: tuple.2,
-        }
-    }
-}
-
 /// Client-side events, asking the engine to send something to the server.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
@@ -274,9 +159,9 @@ pub enum X11Event {
     /// with a layout rectangle.
     FullRefresh,
     /// Key down or up.
-    KeyEvent(ClientKeyEvent),
+    KeyEvent(Key),
     /// Mouse move, button or scroll.
-    PointerEvent(ClientMouseEvent),
+    PointerEvent(Pointer),
     /// Send text to the server's clipboard, the legacy way. Latin-1 only.
     CopyText(String),
     /// Ask the server for the clipboard it announced with
@@ -344,24 +229,11 @@ mod tests {
 
     #[test]
     fn resize_status_codes_match_the_spec() {
-        assert_eq!(ResizeStatus::from(0), ResizeStatus::Success);
-        assert_eq!(ResizeStatus::from(1), ResizeStatus::Prohibited);
-        assert_eq!(ResizeStatus::from(2), ResizeStatus::OutOfResources);
-        assert_eq!(ResizeStatus::from(3), ResizeStatus::InvalidLayout);
-        assert_eq!(ResizeStatus::from(4), ResizeStatus::Forwarded);
-        assert_eq!(ResizeStatus::from(99), ResizeStatus::Unknown(99));
-    }
-
-    #[test]
-    fn only_reason_one_is_a_reply_to_this_client() {
-        let layout = |reason| ScreenLayout {
-            screen: (100, 100).into(),
-            screens: vec![],
-            reason,
-            status: ResizeStatus::Success,
-        };
-        assert!(layout(1).is_reply_to_us());
-        assert!(!layout(0).is_reply_to_us());
-        assert!(!layout(2).is_reply_to_us());
+        assert_eq!(ResizeStatus::from_wire(0), ResizeStatus::Success);
+        assert_eq!(ResizeStatus::from_wire(1), ResizeStatus::Prohibited);
+        assert_eq!(ResizeStatus::from_wire(2), ResizeStatus::OutOfResources);
+        assert_eq!(ResizeStatus::from_wire(3), ResizeStatus::InvalidLayout);
+        assert_eq!(ResizeStatus::from_wire(4), ResizeStatus::Forwarded);
+        assert_eq!(ResizeStatus::from_wire(99), ResizeStatus::Unknown(99));
     }
 }

--- a/src/rfb/mod.rs
+++ b/src/rfb/mod.rs
@@ -50,10 +50,7 @@ pub use client::clipboard::Caps as ClipboardCaps;
 pub use client::{VncClient, VncConnector};
 pub use config::{PixelFormat, VncEncoding, VncVersion, hint};
 pub use error::VncError;
-pub use event::{
-    ClientKeyEvent, ClientMouseEvent, Rect, ResizeStatus, Screen, ScreenInfo, ScreenLayout,
-    VncEvent, X11Event, fence,
-};
+pub use event::{VncEvent, X11Event, fence};
 
 /// Largest allocation we will make on a server's word alone.
 ///

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,8 +1,13 @@
-//! A live VNC session.
+//! A live remote desktop session.
 //!
-//! One loop selects over three sources: events decoded from the server, input
-//! from the terminal, and a render tick. Everything on screen is composed in the
-//! tick and handed to the writer thread as a single frame.
+//! One loop selects over three sources: updates from the remote, input from the
+//! terminal, and a render tick. Everything on screen is composed in the tick and
+//! handed to the writer thread as a single frame.
+//!
+//! Nothing here names a protocol. What arrives comes through [`crate::remote`], and
+//! the two capabilities this loop changes shape around -- whether frames arrive
+//! unasked, and whether a round trip can be measured -- are announced by the backend
+//! rather than assumed.
 
 use std::time::{Duration, Instant};
 
@@ -11,17 +16,16 @@ use crossterm::event::{
     Event, EventStream, KeyCode, KeyEventKind, MouseButton, MouseEvent, MouseEventKind,
 };
 use futures::StreamExt;
-use tokio::net::TcpStream;
 use tokio::time::{MissedTickBehavior, interval};
 
 use crate::app::{FpsMeter, describe, human_bytes};
 use crate::cli::{Args, ScaleMode};
+use crate::remote::{
+    Backend, Connect, ConnectError, Input, Key, ResizeStatus, Screen, ScreenInfo, ScreenLayout,
+    Update,
+};
 use crate::render::framebuffer::Framebuffer;
 use crate::render::{FrameStats, Layout, Rect, Renderer};
-use crate::rfb::{
-    ClipboardCaps, PixelFormat, ResizeStatus, Screen, ScreenInfo, ScreenLayout, VncClient,
-    VncConnector, VncEncoding, VncError, VncEvent, X11Event,
-};
 use crate::term::caps::Caps;
 use crate::term::input::{Command, InputMapper, KeyOutcome, LockState};
 use crate::term::writer::{Busy, FrameWriter};
@@ -30,9 +34,6 @@ use crate::ui::menu::{self, Hit, Menu};
 use crate::ui::status;
 use crate::ui::theme::Theme;
 use crate::ui::toast::Toast;
-
-/// How long to wait for the TCP connection.
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A server that has gone quiet for this long gets its update request repeated.
 /// Some servers drop one under load, and without this the session would simply
@@ -48,14 +49,11 @@ const RESIZE_DEBOUNCE: Duration = Duration::from_millis(250);
 /// incremental request instantly cannot spin us at full speed.
 const MIN_REQUEST_INTERVAL: Duration = Duration::from_millis(2);
 
-/// How often to measure the round trip with a fence, once frames stop being requested.
+/// How often to measure the round trip, once frames stop being requested.
 const RTT_PROBE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// A probe this old was dropped by the server; stop waiting for it.
 const RTT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
-
-/// Marks a fence as our own latency probe rather than a synchronisation request.
-const RTT_PROBE_MARKER: &[u8] = b"desktui-rtt";
 
 /// First pause before a reconnect attempt, doubling up to the cap.
 const RECONNECT_BACKOFF: Duration = Duration::from_millis(500);
@@ -99,32 +97,32 @@ impl Resize {
     }
 }
 
-pub async fn run(
+pub async fn run<C: Connect>(
     args: &Args,
     caps: &Caps,
     guard: &TerminalGuard,
-    addr: &str,
-    password: Option<String>,
+    remote: &mut C,
 ) -> Result<()> {
     // The first connection is made before the alternate screen, so that a
     // password prompt is somewhere the user can see it. Later attempts reuse the
     // password and need no prompt.
-    let (client, password) = connect(addr, password, args).await?;
+    let backend = connect(remote).await?;
     guard.begin_full_screen()?;
 
-    let mut next = Some(client);
+    let addr = remote.address().to_string();
+    let mut next = Some(backend);
     let mut backoff = RECONNECT_BACKOFF;
 
     loop {
-        let client = match next.take() {
-            Some(client) => {
+        let backend = match next.take() {
+            Some(backend) => {
                 backoff = RECONNECT_BACKOFF;
-                client
+                backend
             }
-            None => match try_connect(addr, password.clone(), args).await {
-                Ok(client) => {
+            None => match remote.connect().await {
+                Ok(backend) => {
                     backoff = RECONNECT_BACKOFF;
-                    client
+                    backend
                 }
                 Err(err) => {
                     notice(&format!(
@@ -138,12 +136,12 @@ pub async fn run(
             },
         };
 
-        let mut session = Session::new(args, caps, client).await?;
+        let mut session = Session::new(args, caps, backend).await?;
         let result = session.run(args).await;
         // Let go of anything held on the remote before leaving, so a modifier does
         // not stay stuck in whatever had focus over there.
         session.release_input().await;
-        session.client.close().await;
+        session.backend.close().await;
         drop(session);
 
         match result {
@@ -171,92 +169,28 @@ fn notice(text: &str) {
     let _ = out.flush();
 }
 
-/// Open the connection, prompting for a password only if the server asks for one
+/// Open the connection, prompting for a password only if the remote asks for one
 /// and none was supplied.
-async fn connect(
-    addr: &str,
-    password: Option<String>,
-    args: &Args,
-) -> Result<(VncClient, Option<String>)> {
-    match try_connect(addr, password.clone(), args).await {
-        Ok(client) => Ok((client, password)),
-        Err(VncError::NoPassword) => {
-            let password = crate::prompt_password(addr)?;
-            let client = try_connect(addr, Some(password.clone()), args)
+///
+/// The password is handed back to the connector rather than kept here, so that a
+/// reconnect an hour later needs no prompt.
+async fn connect<C: Connect>(remote: &mut C) -> Result<C::Backend> {
+    match remote.connect().await {
+        Ok(backend) => Ok(backend),
+        Err(ConnectError::NeedsPassword) => {
+            let password = crate::prompt_password(remote.address())?;
+            remote.use_password(password);
+            remote
+                .connect()
                 .await
-                .map_err(|err| anyhow::anyhow!("{err}"))?;
-            Ok((client, Some(password)))
+                .map_err(|err| anyhow::anyhow!("{err}"))
         }
-        Err(err) => Err(anyhow::anyhow!("{err}")).with_context(|| format!("connecting to {addr}")),
+        Err(ConnectError::Failed(err)) => Err(err),
     }
 }
 
-async fn try_connect(
-    addr: &str,
-    password: Option<String>,
-    args: &Args,
-) -> Result<VncClient, VncError> {
-    // Not in a view-only session: there is no local pointer worth drawing there, and
-    // letting the server composite its own is the only way to see where the real one
-    // is.
-    let local_cursor = !args.view_only;
-    let stream = tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(addr))
-        .await
-        .map_err(|_| VncError::General(format!("timed out connecting to {addr}")))?
-        .map_err(VncError::IoError)?;
-    // Input latency is the whole point; do not let Nagle sit on a click.
-    stream.set_nodelay(true).map_err(VncError::IoError)?;
-
-    VncConnector::new(stream)
-        .set_auth_method(async move { password.ok_or(VncError::NoPassword) })
-        // Order is preference order. Tight first: it is what every modern server
-        // does best, and its JPEG rectangles are the cheapest way to move a busy
-        // screen.
-        .add_encoding(VncEncoding::Tight)
-        .add_encoding(VncEncoding::Zrle)
-        .add_encoding(VncEncoding::CopyRect)
-        .add_encoding(VncEncoding::Raw)
-        .add_encoding(VncEncoding::ExtendedDesktopSizePseudo)
-        .add_encoding(VncEncoding::DesktopSizePseudo)
-        .add_encoding(VncEncoding::LastRectPseudo)
-        // Ask the server to push frames rather than answer a request each time, which
-        // saves a round trip per frame; Fence is what makes that safe to negotiate.
-        .add_encoding(VncEncoding::ContinuousUpdatesPseudo)
-        .add_encoding(VncEncoding::FencePseudo)
-        // And to tell us its lock-key state, so a caps lock that disagrees with the
-        // local keyboard can be corrected instead of shouting.
-        .add_encoding(VncEncoding::QemuLedStatePseudo)
-        // Asking for the cursor shape stops the server drawing the pointer into the
-        // framebuffer, which is what lets it move at local speed instead of waiting for
-        // a round trip.
-        .add_encodings(if local_cursor {
-            &[VncEncoding::CursorPseudo][..]
-        } else {
-            &[]
-        })
-        // The clipboard in UTF-8 rather than Latin-1, and announced rather than pushed.
-        // Left out entirely with --no-clipboard: the encoding is a standing offer to
-        // exchange clipboards, and a session that wants none should not make it.
-        .add_encodings(if args.no_clipboard {
-            &[]
-        } else {
-            &[VncEncoding::ExtendedClipboardPseudo][..]
-        })
-        .set_quality(args.quality)
-        .set_compression(args.compression)
-        .allow_shared(true)
-        // BGRA is what an x86 server produces natively, so this is the format
-        // that costs neither side a swizzle on the wire. The pack to RGB happens
-        // once per tile at the end of the pipeline.
-        .set_pixel_format(PixelFormat::bgra())
-        .build()?
-        .try_start()
-        .await?
-        .finish()
-}
-
-struct Session {
-    client: VncClient,
+struct Session<B: Backend> {
+    backend: B,
     fb: Framebuffer,
     renderer: Renderer,
     writer: FrameWriter,
@@ -285,18 +219,15 @@ struct Session {
     /// measure against, and showing the age of the last request we happened to send
     /// would be a number that only ever grows.
     rtt: Option<Duration>,
-    /// The server has sent us a fence, so it understands them and can be asked to
-    /// bounce one back.
-    fence_supported: bool,
+    /// The backend has said it can measure a round trip.
+    can_probe_latency: bool,
     /// When the outstanding latency probe went out.
     rtt_probe_at: Option<Instant>,
     /// When the last measurement completed, to space the probes out.
     rtt_measured_at: Option<Instant>,
-    /// The server pushes updates without being asked, so no requests are sent.
-    continuous_updates: bool,
-    /// The rectangle continuous updates was last enabled for, so a resize can tell
-    /// whether it needs to say so again.
-    continuous_rect: Option<(u16, u16)>,
+    /// Frames arrive without being asked for, so no requests are sent. How the
+    /// backend arranged that is its own business.
+    pushed_frames: bool,
     /// The remote lock-key state, when the server tells us. `None` means unknown,
     /// which is also what it becomes right after a correction is sent: the answer
     /// takes a moment to arrive and acting twice would toggle it back.
@@ -305,16 +236,11 @@ struct Session {
 
     view_only: bool,
     no_clipboard: bool,
-    /// What the server accepts on the extended clipboard, once its `caps` message has
-    /// arrived. `None` means the extension is not in play, and the Latin-1 `CutText`
-    /// messages are all there is.
-    clipboard_caps: Option<ClipboardCaps>,
-    /// Text we have told the server we hold and have not been asked for yet.
-    ///
-    /// The extension moves ownership before it moves data: a local paste announces
-    /// itself, and the bytes go over when something on the remote side pastes. Kept
-    /// rather than taken when that happens, because it can be pasted more than once.
-    announced_clipboard: Option<String>,
+    /// Text put on the remote clipboard will not survive intact, so anything outside
+    /// Latin-1 has to be warned about. True until a backend says otherwise: the
+    /// answer takes a negotiation, and the pessimistic assumption is the safe one to
+    /// start on.
+    clipboard_lossy: bool,
     /// Which palette the chrome wears. Dark to start, the bar having been that colour
     /// before there was a choice.
     theme: Theme,
@@ -338,11 +264,11 @@ struct Session {
     quit: bool,
 }
 
-impl Session {
-    async fn new(args: &Args, caps: &Caps, client: VncClient) -> Result<Self> {
+impl<B: Backend> Session<B> {
+    async fn new(args: &Args, caps: &Caps, backend: B) -> Result<Self> {
         let metrics = Metrics::query()?;
-        let remote = client.resolution().await;
-        let server_name = client.name().await;
+        let remote = backend.resolution().await;
+        let server_name = backend.name().await;
 
         let fb = Framebuffer::new(u32::from(remote.0), u32::from(remote.1));
         let layout = Layout::compute(
@@ -354,7 +280,7 @@ impl Session {
         );
 
         Ok(Self {
-            client,
+            backend,
             fb,
             renderer: Renderer::new(layout, true, args.transfer.resolve(caps)),
             writer: FrameWriter::spawn(),
@@ -371,17 +297,15 @@ impl Session {
             awaiting_update: true, // the engine asks for the first frame itself
             requested_at: Instant::now(),
             rtt: None,
-            fence_supported: false,
+            can_probe_latency: false,
             rtt_probe_at: None,
             rtt_measured_at: None,
-            continuous_updates: false,
-            continuous_rect: None,
+            pushed_frames: false,
             remote_caps_lock: None,
             remote_num_lock: None,
             view_only: args.view_only,
             no_clipboard: args.no_clipboard,
-            clipboard_caps: None,
-            announced_clipboard: None,
+            clipboard_lossy: true,
             theme: Theme::Dark,
             menu: Menu::new(args.prefix_char()),
             show_menu: false,
@@ -406,8 +330,8 @@ impl Session {
 
         while !self.quit {
             tokio::select! {
-                event = self.client.recv_event() => match event {
-                    Ok(event) => self.on_vnc(event).await?,
+                update = self.backend.recv() => match update {
+                    Ok(update) => self.on_update(update).await?,
                     Err(err) => {
                         anyhow::bail!("the session ended: {err}");
                     }
@@ -422,14 +346,14 @@ impl Session {
         Ok(())
     }
 
-    async fn on_vnc(&mut self, event: VncEvent) -> Result<()> {
-        match event {
-            VncEvent::RawImage(rect, data) => {
+    async fn on_update(&mut self, update: Update) -> Result<()> {
+        match update {
+            Update::Bgra(rect, data) => {
                 if let Some(damage) = self.fb.apply_bgra(convert(rect), &data) {
                     self.renderer.mark(damage);
                 }
             }
-            VncEvent::JpegImage(rect, data) => match decode_jpeg(&data) {
+            Update::Jpeg(rect, data) => match decode_jpeg(&data) {
                 Ok((w, h, rgb)) => {
                     // Trust the rectangle header for placement, but the JPEG for
                     // its own dimensions.
@@ -440,27 +364,26 @@ impl Session {
                 }
                 Err(err) => tracing::warn!("dropping an undecodable JPEG rectangle: {err}"),
             },
-            VncEvent::Copy(dst, src) => {
+            Update::Copy { dst, from } => {
                 if let Some(damage) =
                     self.fb
-                        .copy_rect(convert(dst), u32::from(src.x), u32::from(src.y))
+                        .copy_rect(convert(dst), u32::from(from.0), u32::from(from.1))
                 {
                     self.renderer.mark(damage);
                 }
             }
-            VncEvent::SetResolution(screen) => self.on_remote_size(screen, None).await?,
-            VncEvent::DesktopLayout(layout) => self.on_layout(layout).await?,
-            VncEvent::FramebufferUpdateEnd => {
-                // Only meaningful when this update answers a request of ours. With
-                // continuous updates there is no pair, and the fence probe measures it
-                // instead.
-                if self.awaiting_update && !self.continuous_updates {
+            Update::Resolution(screen) => self.on_remote_size(screen, None).await?,
+            Update::Layout(layout) => self.on_layout(layout).await?,
+            Update::FrameEnd => {
+                // Only meaningful when this frame answers a request of ours. With
+                // frames arriving unbidden there is no pair, and the latency probe
+                // measures it instead.
+                if self.awaiting_update && !self.pushed_frames {
                     self.rtt = Some(self.requested_at.elapsed());
                 }
                 self.awaiting_update = false;
-                // The first update is also the answer to our capability probe: a
-                // server that supports resizing must have included a layout
-                // rectangle in it.
+                // The first frame is also the answer to our capability probe: a
+                // remote that supports resizing must have reported a layout with it.
                 if self.resize == Resize::Probing {
                     self.resize = Resize::Unsupported;
                     if let Some(note) = self.resize.note() {
@@ -468,110 +391,74 @@ impl Session {
                     }
                     self.fall_back_from_native();
                 }
-                // Ask for the next update now, not on the next render tick. The
-                // server can then encode the following frame while we are still
+                // Ask for the next frame now, not on the next render tick. The
+                // remote can then encode the following one while we are still
                 // drawing this one; waiting for the tick leaves it idle for up to a
                 // whole frame interval, which roughly halves the rate a moving
                 // picture can reach.
                 self.request_update().await?;
             }
-            VncEvent::Text(text) => {
+            Update::Clipboard(text) => {
                 if !self.no_clipboard {
                     self.copy_to_local_clipboard(&text);
                 }
             }
-            VncEvent::ClipboardCaps(caps) => {
-                // The extension is live from here: the clipboard is UTF-8 in both
-                // directions, and a remote selection arrives as an announcement rather
-                // than as a copy of itself.
-                tracing::debug!("extended clipboard negotiated: {caps:?}");
-                self.clipboard_caps = Some(caps);
+            Update::ClipboardLossy(lossy) => {
+                // Whether text put on the remote clipboard survives intact. A session
+                // assumes it does not until told otherwise, because the answer takes a
+                // negotiation and the pessimistic path is the safe one to start on.
+                tracing::debug!(
+                    "remote clipboard is {}",
+                    if lossy { "Latin-1" } else { "UTF-8" }
+                );
+                self.clipboard_lossy = lossy;
             }
-            VncEvent::ClipboardNotify { text } => {
-                // Nothing has been transferred yet -- that is the point of a notify --
-                // so ask for it. With --no-clipboard the extension was never
-                // advertised, so this cannot arrive; the check is belt and braces
-                // around a server that sends one anyway.
-                if text && !self.no_clipboard {
-                    self.send(X11Event::ClipboardRequest).await?;
-                }
-            }
-            VncEvent::ClipboardRequest => {
-                // Something on the remote side pasted, so the text we announced is
-                // wanted now.
-                match self.announced_clipboard.clone() {
-                    Some(text) if !self.view_only && !self.no_clipboard => {
-                        tracing::debug!("sending the announced clipboard, {} bytes", text.len());
-                        self.send(X11Event::ClipboardProvide(text)).await?;
-                    }
-                    _ => tracing::debug!("server asked for a clipboard we never announced"),
-                }
-            }
-            VncEvent::Bell => {
+            Update::Bell => {
                 // A bell is the one thing worth passing straight through.
                 let mut buf = self.writer.take_buffer();
                 buf.push(0x07);
                 let _ = self.writer.submit_blocking(buf);
             }
-            VncEvent::SetPixelFormat(pf) => {
-                tracing::debug!("server pixel format: {pf:?}");
-            }
-            VncEvent::LedState { num, caps, .. } => {
+            Update::LockKeys { num, caps } => {
                 // Only useful as something to compare the local keyboard against, so
-                // scroll lock is ignored: no terminal reports it.
+                // scroll lock never crosses the seam: no terminal reports it.
                 tracing::debug!("remote lock keys: caps={caps} num={num}");
                 self.remote_caps_lock = Some(caps);
                 self.remote_num_lock = Some(num);
             }
-            VncEvent::EndOfContinuousUpdates => {
-                // The first one of these is the server saying the extension exists.
-                // Any later one means it stopped, and asking again is how it restarts.
-                if !self.continuous_updates {
-                    tracing::info!("server supports continuous updates; enabling");
-                    self.set_note("continuous updates: the server pushes frames".into());
+            Update::Pushing(pushing) => {
+                if pushing && !self.pushed_frames {
+                    tracing::info!("frames now arrive without being asked for");
+                    self.set_note("the remote is pushing frames".into());
                 }
-                self.continuous_updates = false;
-                self.continuous_rect = None;
-                self.enable_continuous_updates().await?;
-            }
-            VncEvent::Fence { flags, payload } => {
-                tracing::debug!(
-                    "fence from server, flags {flags:#x}, {} bytes",
-                    payload.len()
-                );
-                // A fence at all means the server understands them, which is what makes
-                // the latency probe possible.
-                self.fence_supported = true;
-                // A fence with the request bit set has to come back with that bit
-                // cleared, along with any flag we do not understand. Ours arrive in
-                // order and are handled one at a time, which is what BlockBefore and
-                // BlockAfter ask for, so echoing is all there is to do.
-                if flags & crate::rfb::fence::REQUEST != 0 {
-                    let echo =
-                        flags & (crate::rfb::fence::BLOCK_BEFORE | crate::rfb::fence::BLOCK_AFTER);
-                    self.send(X11Event::Fence {
-                        flags: echo,
-                        payload,
-                    })
-                    .await?;
-                } else if payload == RTT_PROBE_MARKER {
-                    // Our own probe, back again: the gap is the round trip.
-                    if let Some(sent) = self.rtt_probe_at.take() {
-                        self.rtt = Some(sent.elapsed());
-                        self.rtt_measured_at = Some(Instant::now());
-                    }
-                } else {
-                    tracing::debug!("unsolicited fence response, flags {flags:#x}");
+                self.pushed_frames = pushing;
+                // Nothing is outstanding any more: frames arrive unbidden from here.
+                if pushing {
+                    self.awaiting_update = false;
                 }
             }
-            VncEvent::SetCursor(rect, pixels) => {
-                // The rectangle's x and y are the hotspot rather than a position.
+            Update::LatencyAvailable => {
+                tracing::debug!("the remote can measure a round trip");
+                self.can_probe_latency = true;
+            }
+            Update::LatencyProbe => {
+                // Our own probe, back again: the gap is the round trip.
+                if let Some(sent) = self.rtt_probe_at.take() {
+                    self.rtt = Some(sent.elapsed());
+                    self.rtt_measured_at = Some(Instant::now());
+                }
+            }
+            Update::Cursor {
+                size,
+                hotspot,
+                bgra,
+            } => {
                 let cursor = crate::render::Cursor {
-                    w: u32::from(rect.width),
-                    h: u32::from(rect.height),
-                    hot_x: u32::from(rect.x),
-                    hot_y: u32::from(rect.y),
-                    pixels,
+                    w: u32::from(size.0),
+                    h: u32::from(size.1),
+                    hot_x: u32::from(hotspot.0),
+                    hot_y: u32::from(hotspot.1),
+                    pixels: bgra,
                 };
                 tracing::debug!(
                     "cursor shape {}x{} hotspot {},{}",
@@ -582,7 +469,7 @@ impl Session {
                 );
                 self.renderer.set_cursor(Some(cursor));
             }
-            VncEvent::Error(err) => anyhow::bail!("the server connection failed: {err}"),
+            Update::Error(err) => anyhow::bail!("the remote connection failed: {err}"),
         }
         Ok(())
     }
@@ -616,15 +503,6 @@ impl Session {
         self.relayout();
         if let Some(note) = note {
             self.set_note(note);
-        }
-
-        // The server remembers which rectangle it was told to push, and a resize does
-        // not change its mind. Saying so again is the whole difference between a
-        // desktop that grows and one that grows a black band down two sides: the region
-        // beyond the old rectangle is never sent otherwise.
-        if self.continuous_updates {
-            self.continuous_rect = None;
-            self.enable_continuous_updates().await?;
         }
         Ok(())
     }
@@ -741,14 +619,13 @@ impl Session {
         self.resize = Resize::Waiting { want };
         self.requested_size = Some(want);
         self.requested_at = Instant::now();
-        self.client
-            .input(X11Event::SetDesktopSize {
+        self.backend
+            .send(Input::Resize {
                 width: want.0,
                 height: want.1,
                 screens,
             })
-            .await
-            .map_err(|err| anyhow::anyhow!("{err}"))?;
+            .await?;
         Ok(())
     }
 
@@ -790,7 +667,7 @@ impl Session {
                             if !self.view_only {
                                 self.sync_lock_keys(locks).await?;
                                 for key in keys {
-                                    self.send(X11Event::KeyEvent(key)).await?;
+                                    self.send(Input::Key(key)).await?;
                                 }
                             }
                         }
@@ -810,7 +687,7 @@ impl Session {
                             // remote interprets *this* key with the right lock state.
                             self.sync_lock_keys(locks).await?;
                             for key in keys {
-                                self.send(X11Event::KeyEvent(key)).await?;
+                                self.send(Input::Key(key)).await?;
                             }
                         }
                     }
@@ -870,7 +747,7 @@ impl Session {
                         self.input.on_mouse(mouse, &layout, &self.metrics)
                     };
                     for event in events {
-                        self.send(X11Event::PointerEvent(event)).await?;
+                        self.send(Input::Pointer(event)).await?;
                     }
                 }
             }
@@ -899,13 +776,13 @@ impl Session {
             Command::SendPrefix => {
                 if !self.view_only {
                     for key in self.input.literal_prefix() {
-                        self.send(X11Event::KeyEvent(key)).await?;
+                        self.send(Input::Key(key)).await?;
                     }
                 }
             }
             Command::FullRefresh => {
                 self.renderer.mark_all();
-                self.send(X11Event::FullRefresh).await?;
+                self.send(Input::Refresh { incremental: false }).await?;
                 self.awaiting_update = true;
                 self.requested_at = Instant::now();
                 self.set_note("full refresh requested".into());
@@ -1071,15 +948,15 @@ impl Session {
             }
         }
 
-        // With frames arriving unbidden there is no request to time, so ask the server
-        // to bounce a fence back and measure that instead.
+        // With frames arriving unbidden there is no request to time, so ask for a
+        // round trip and measure that instead.
         self.probe_round_trip().await?;
 
         // A pointer that stopped moving mid-rate-limit still has to arrive.
         if !self.view_only
             && let Some(pointer) = self.input.flush_motion()
         {
-            self.send(X11Event::PointerEvent(pointer)).await?;
+            self.send(Input::Pointer(pointer)).await?;
         }
 
         // Normally the request went out the moment the last update finished, so
@@ -1087,43 +964,16 @@ impl Session {
         // gone quiet.
         if !self.awaiting_update {
             self.request_update().await?;
-        } else if !self.continuous_updates && self.requested_at.elapsed() > UPDATE_WATCHDOG {
+        } else if !self.pushed_frames && self.requested_at.elapsed() > UPDATE_WATCHDOG {
             tracing::debug!(
                 "no update for {:?}; asking again",
                 self.requested_at.elapsed()
             );
             self.requested_at = Instant::now();
-            self.send(X11Event::Refresh).await?;
+            self.send(Input::Refresh { incremental: true }).await?;
         }
 
         self.draw()
-    }
-
-    /// Ask the server to push updates for the whole framebuffer.
-    ///
-    /// Re-sent after a resize: the rectangle is remembered by the server, and the
-    /// spec says a second enable replaces the coordinates rather than adding to them.
-    async fn enable_continuous_updates(&mut self) -> Result<()> {
-        let size = self.remote;
-        if self.continuous_updates && self.continuous_rect == Some(size) {
-            return Ok(());
-        }
-        self.send(X11Event::EnableContinuousUpdates {
-            enable: true,
-            rect: crate::rfb::Rect {
-                x: 0,
-                y: 0,
-                width: size.0,
-                height: size.1,
-            },
-        })
-        .await?;
-        tracing::debug!("continuous updates enabled for {}x{}", size.0, size.1);
-        self.continuous_updates = true;
-        self.continuous_rect = Some(size);
-        // Nothing is outstanding any more: frames arrive unbidden from here.
-        self.awaiting_update = false;
-        Ok(())
     }
 
     /// Bring the remote lock keys into line with the local keyboard.
@@ -1153,23 +1003,21 @@ impl Session {
         for (name, keysym) in corrections {
             tracing::debug!("correcting remote {name}");
             for down in [true, false] {
-                self.send(X11Event::KeyEvent(crate::rfb::ClientKeyEvent {
-                    keycode: keysym,
-                    down,
-                }))
-                .await?;
+                self.send(Input::Key(Key { keysym, down })).await?;
             }
         }
         Ok(())
     }
 
-    /// Measure the round trip with a fence, when there are no requests to measure.
+    /// Measure the round trip, when there are no requests to measure.
     ///
-    /// Frames pushed by the server carry no timing information: they answer nothing.
-    /// A fence does -- the server bounces it straight back, which is the only honest
-    /// latency figure available once requests stop.
+    /// Frames that arrive unbidden carry no timing information: they answer nothing.
+    /// A probe does -- the remote sends it straight back -- and is the only honest
+    /// latency figure available once requests stop. A backend that cannot measure one
+    /// leaves the figure unknown, which the status line shows as dashes rather than
+    /// inventing a number.
     async fn probe_round_trip(&mut self) -> Result<()> {
-        if !self.continuous_updates || !self.fence_supported {
+        if !self.pushed_frames || !self.can_probe_latency {
             return Ok(());
         }
         // A probe that never came back was dropped; stop waiting on it.
@@ -1189,12 +1037,7 @@ impl Session {
         }
 
         self.rtt_probe_at = Some(Instant::now());
-        // No block flags: the server can answer immediately, which is the point.
-        self.send(X11Event::Fence {
-            flags: crate::rfb::fence::REQUEST,
-            payload: RTT_PROBE_MARKER.to_vec(),
-        })
-        .await
+        self.send(Input::ProbeLatency).await
     }
 
     /// Ask for the next incremental update, keeping one in flight at a time.
@@ -1204,8 +1047,8 @@ impl Session {
     /// request until something changes, and a server that does not would otherwise
     /// have us both spinning at full tilt.
     async fn request_update(&mut self) -> Result<()> {
-        // The server is pushing frames; asking as well would undo the point of it.
-        if self.continuous_updates {
+        // Frames are being pushed; asking as well would undo the point of it.
+        if self.pushed_frames {
             return Ok(());
         }
         if self.awaiting_update {
@@ -1217,7 +1060,7 @@ impl Session {
         }
         self.awaiting_update = true;
         self.requested_at = Instant::now();
-        self.send(X11Event::Refresh).await
+        self.send(Input::Refresh { incremental: true }).await
     }
 
     fn draw(&mut self) -> Result<()> {
@@ -1352,61 +1195,37 @@ impl Session {
         }
     }
 
-    async fn send(&self, event: X11Event) -> Result<()> {
-        self.client
-            .input(event)
+    async fn send(&self, input: Input) -> Result<()> {
+        self.backend
+            .send(input)
             .await
-            .map_err(|err| anyhow::anyhow!("failed to send input: {err}"))
+            .context("failed to send input")
     }
 
     /// Let go of every key and button we told the server about.
     async fn release_input(&mut self) {
         for key in self.input.release_all() {
-            let _ = self.client.input(X11Event::KeyEvent(key)).await;
+            let _ = self.backend.send(Input::Key(key)).await;
         }
         if let Some(pointer) = self.input.release_buttons() {
-            let _ = self.client.input(X11Event::PointerEvent(pointer)).await;
+            let _ = self.backend.send(Input::Pointer(pointer)).await;
         }
     }
 
     /// Put locally pasted text on the remote clipboard.
     ///
-    /// Over the extension the text goes as UTF-8 and arrives whole. Without it the
-    /// payload is Latin-1 and everything outside it has to be substituted, which is
-    /// why a server that negotiated the extension is worth the extra round trip.
+    /// How it gets there is the backend's business -- which message, whether the text
+    /// goes now or is announced and fetched later. The one thing that belongs here is
+    /// telling the user when the remote cannot carry what they pasted, because a
+    /// substitution they were not warned about is a substitution they will find later
+    /// in whatever they pasted into.
     async fn paste_to_remote(&mut self, text: String) -> Result<()> {
-        if let Some(caps) = self
-            .clipboard_caps
-            .filter(|caps: &ClipboardCaps| caps.takes_text() && caps.takes_provide())
-        {
-            // The size the server's limit applies to is the text as it goes on the
-            // wire: CRLF line endings, and the terminating null that the length counts.
-            let wire_len = text.len() + text.matches('\n').count() + 1;
-            if wire_len as u64 <= u64::from(caps.unsolicited_text()) || !caps.takes_notify() {
-                // Either small enough to push unasked, or a server that offered no way
-                // to announce it, which leaves pushing it the only thing left to try.
-                self.send(X11Event::ClipboardProvide(text)).await?;
-            } else {
-                // Announce it and keep it. The server asks when something over there
-                // pastes, which is the point: a clipboard nobody reads costs one small
-                // message instead of the whole text.
-                self.send(X11Event::ClipboardNotify).await?;
-                self.announced_clipboard = Some(text);
-            }
-            self.set_note("pasted to the remote clipboard".into());
-            return Ok(());
-        }
-
-        // Legacy `ClientCutText` is Latin-1 only. Substitute rather than drop:
-        // deleting characters silently shortens the text and moves everything after
-        // them, where a question mark leaves the shape intact and is visibly a
-        // substitution. noVNC does the same.
-        let dropped = text.chars().filter(|c| (*c as u32) > 0xff).count();
-        let latin1: String = text
-            .chars()
-            .map(|c| if (c as u32) > 0xff { '?' } else { c })
-            .collect();
-        self.send(X11Event::CopyText(latin1)).await?;
+        let dropped = if self.clipboard_lossy {
+            text.chars().filter(|c| (*c as u32) > 0xff).count()
+        } else {
+            0
+        };
+        self.send(Input::Clipboard(text)).await?;
         self.set_note(if dropped > 0 {
             format!("pasted; {dropped} character(s) are not Latin-1 and became '?'")
         } else {
@@ -1451,7 +1270,7 @@ fn format_rtt(rtt: Option<Duration>) -> String {
     }
 }
 
-fn convert(rect: crate::rfb::Rect) -> Rect {
+fn convert(rect: crate::remote::Rect) -> Rect {
     Rect::new(
         u32::from(rect.x),
         u32::from(rect.y),
@@ -1531,7 +1350,7 @@ mod tests {
 
     #[test]
     fn a_rectangle_widens_from_the_protocol_type() {
-        let rect = convert(crate::rfb::Rect {
+        let rect = convert(crate::remote::Rect {
             x: 10,
             y: 20,
             width: 30,

--- a/src/term/input.rs
+++ b/src/term/input.rs
@@ -1,8 +1,8 @@
-//! Terminal input to RFB input.
+//! Terminal input to remote input.
 //!
 //! Two things make this more than a lookup table.
 //!
-//! **Releases.** RFB wants a down and an up for every key. The Kitty keyboard
+//! **Releases.** The remote wants a down and an up for every key. The Kitty keyboard
 //! protocol provides both; a terminal without it reports only presses, so the
 //! release has to be synthesised straight after. Which of the two we are dealing
 //! with is settled by the capability probe rather than guessed at from traffic.
@@ -24,8 +24,8 @@ use crossterm::event::{
 use super::Metrics;
 use super::keysym::{bitmask, keysym};
 use crate::cli::ScaleMode;
+use crate::remote::{Key, Pointer};
 use crate::render::Layout;
-use crate::rfb::{ClientKeyEvent, ClientMouseEvent};
 use crate::ui::theme::Theme;
 
 /// Shortest gap between two motion reports, about 60 a second.
@@ -36,7 +36,8 @@ use crate::ui::theme::Theme;
 /// lost -- only intermediate positions the remote would not have noticed.
 const MOTION_INTERVAL: Duration = Duration::from_millis(17);
 
-/// VNC pointer button bits, from RFC 6143 section 7.5.5.
+/// Pointer button bits, from RFC 6143 section 7.5.5, which is how they cross the
+/// seam in [`Pointer`].
 mod button {
     pub const LEFT: u8 = 1 << 0;
     pub const MIDDLE: u8 = 1 << 1;
@@ -88,7 +89,7 @@ pub enum KeyOutcome {
     /// Nothing to do: swallowed, or unmapped.
     Ignored,
     /// Send these to the server, in order.
-    Keys(Vec<ClientKeyEvent>),
+    Keys(Vec<Key>),
     /// Handle this locally.
     Local(Command),
 }
@@ -227,7 +228,7 @@ impl InputMapper {
     }
 
     /// Send the prefix chord through to the server, as if it had not been caught.
-    pub fn literal_prefix(&mut self) -> Vec<ClientKeyEvent> {
+    pub fn literal_prefix(&mut self) -> Vec<Key> {
         let mut out = Vec::new();
         let ctrl = bitmask::CONTROL;
         let key = super::keysym::keysym_for_char(self.prefix);
@@ -269,7 +270,7 @@ impl InputMapper {
     }
 
     /// Bring the remote's modifier state in line with the reported bitmask.
-    fn sync_modifiers(&mut self, out: &mut Vec<ClientKeyEvent>, want: KeyModifiers) {
+    fn sync_modifiers(&mut self, out: &mut Vec<Key>, want: KeyModifiers) {
         for (flag, sym) in [
             (KeyModifiers::SHIFT, bitmask::SHIFT),
             (KeyModifiers::CONTROL, bitmask::CONTROL),
@@ -290,19 +291,19 @@ impl InputMapper {
         }
     }
 
-    fn press(&mut self, out: &mut Vec<ClientKeyEvent>, sym: u32) {
+    fn press(&mut self, out: &mut Vec<Key>, sym: u32) {
         self.held.insert(sym);
-        out.push(ClientKeyEvent {
-            keycode: sym,
+        out.push(Key {
+            keysym: sym,
             down: true,
         });
     }
 
     /// Release a key, but only if we told the server it was down.
-    fn release(&mut self, out: &mut Vec<ClientKeyEvent>, sym: u32) {
+    fn release(&mut self, out: &mut Vec<Key>, sym: u32) {
         if self.held.remove(&sym) {
-            out.push(ClientKeyEvent {
-                keycode: sym,
+            out.push(Key {
+                keysym: sym,
                 down: false,
             });
         }
@@ -310,17 +311,17 @@ impl InputMapper {
 
     /// Release everything still held. Called when leaving, losing focus, or
     /// reconnecting: a modifier left down on the remote outlives us.
-    pub fn release_all(&mut self) -> Vec<ClientKeyEvent> {
+    pub fn release_all(&mut self) -> Vec<Key> {
         let mut out: Vec<_> = self
             .held
             .drain()
-            .map(|sym| ClientKeyEvent {
-                keycode: sym,
+            .map(|sym| Key {
+                keysym: sym,
                 down: false,
             })
             .collect();
         // Deterministic order makes the traffic reproducible in tests and logs.
-        out.sort_by_key(|e| e.keycode);
+        out.sort_by_key(|e| e.keysym);
         self.synthesised = KeyModifiers::NONE;
         out
     }
@@ -359,12 +360,7 @@ impl InputMapper {
     ///
     /// Returns nothing when the pointer is outside the drawn image, so a click on
     /// the letterbox is not reported as a click on the nearest edge.
-    pub fn on_mouse(
-        &mut self,
-        ev: MouseEvent,
-        layout: &Layout,
-        metrics: &Metrics,
-    ) -> Vec<ClientMouseEvent> {
+    pub fn on_mouse(&mut self, ev: MouseEvent, layout: &Layout, metrics: &Metrics) -> Vec<Pointer> {
         let (tx, ty) = self.terminal_pixel(&ev, metrics);
         let Some((x, y)) = layout.terminal_px_to_src(tx, ty) else {
             return Vec::new();
@@ -410,14 +406,14 @@ impl InputMapper {
                     _ => button::WHEEL_RIGHT,
                 };
                 self.last_position = Some((x, y));
-                out.push(ClientMouseEvent {
-                    position_x: x,
-                    position_y: y,
+                out.push(Pointer {
+                    x,
+                    y,
                     buttons: self.buttons | bit,
                 });
-                out.push(ClientMouseEvent {
-                    position_x: x,
-                    position_y: y,
+                out.push(Pointer {
+                    x,
+                    y,
                     buttons: self.buttons,
                 });
                 return out;
@@ -425,9 +421,9 @@ impl InputMapper {
         }
 
         self.last_position = Some((x, y));
-        out.push(ClientMouseEvent {
-            position_x: x,
-            position_y: y,
+        out.push(Pointer {
+            x,
+            y,
             buttons: self.buttons,
         });
         out
@@ -437,7 +433,7 @@ impl InputMapper {
     ///
     /// Called from the render tick, so a pointer that stops moving still ends up
     /// where the user left it.
-    pub fn flush_motion(&mut self) -> Option<ClientMouseEvent> {
+    pub fn flush_motion(&mut self) -> Option<Pointer> {
         let (x, y) = self.pending_motion?;
         if let Some(last) = self.last_motion
             && last.elapsed() < MOTION_INTERVAL
@@ -447,40 +443,36 @@ impl InputMapper {
         self.pending_motion = None;
         self.last_motion = Some(Instant::now());
         self.last_position = Some((x, y));
-        Some(ClientMouseEvent {
-            position_x: x,
-            position_y: y,
+        Some(Pointer {
+            x,
+            y,
             buttons: self.buttons,
         })
     }
 
     /// Emit a held-back position immediately, before an event that must not be
     /// reordered behind it.
-    fn flush_pending(&mut self, out: &mut Vec<ClientMouseEvent>) {
+    fn flush_pending(&mut self, out: &mut Vec<Pointer>) {
         if let Some((x, y)) = self.pending_motion.take() {
             self.last_motion = Some(Instant::now());
             self.last_position = Some((x, y));
-            out.push(ClientMouseEvent {
-                position_x: x,
-                position_y: y,
+            out.push(Pointer {
+                x,
+                y,
                 buttons: self.buttons,
             });
         }
     }
 
     /// Let go of every pointer button, for the same reason as `release_all`.
-    pub fn release_buttons(&mut self) -> Option<ClientMouseEvent> {
+    pub fn release_buttons(&mut self) -> Option<Pointer> {
         if self.buttons == 0 {
             return None;
         }
         self.buttons = 0;
         self.pending_motion = None;
         let (x, y) = self.last_position.unwrap_or((0, 0));
-        Some(ClientMouseEvent {
-            position_x: x,
-            position_y: y,
-            buttons: 0,
-        })
+        Some(Pointer { x, y, buttons: 0 })
     }
 }
 
@@ -561,15 +553,15 @@ mod tests {
         let mut input = InputMapper::new('a', true, true);
         assert_eq!(
             input.on_key(press(KeyCode::Char('x'))),
-            KeyOutcome::Keys(vec![ClientKeyEvent {
-                keycode: 0x78,
+            KeyOutcome::Keys(vec![Key {
+                keysym: 0x78,
                 down: true
             }])
         );
         assert_eq!(
             input.on_key(release(KeyCode::Char('x'))),
-            KeyOutcome::Keys(vec![ClientKeyEvent {
-                keycode: 0x78,
+            KeyOutcome::Keys(vec![Key {
+                keysym: 0x78,
                 down: false
             }])
         );
@@ -584,7 +576,7 @@ mod tests {
         assert_eq!(events.len(), 2, "{events:?}");
         assert!(events[0].down);
         assert!(!events[1].down);
-        assert_eq!(events[0].keycode, events[1].keycode);
+        assert_eq!(events[0].keysym, events[1].keysym);
     }
 
     #[test]
@@ -600,12 +592,12 @@ mod tests {
         // Shift down, c down, c up. Shift stays down until it is reported gone.
         assert_eq!(
             events[0],
-            ClientKeyEvent {
-                keycode: bitmask::SHIFT,
+            Key {
+                keysym: bitmask::SHIFT,
                 down: true
             }
         );
-        assert_eq!(events[1].keycode, 0x63);
+        assert_eq!(events[1].keysym, 0x63);
         assert!(!events[2].down);
 
         // Now without shift: it has to be released.
@@ -614,8 +606,8 @@ mod tests {
         };
         assert_eq!(
             events[0],
-            ClientKeyEvent {
-                keycode: bitmask::SHIFT,
+            Key {
+                keysym: bitmask::SHIFT,
                 down: false
             }
         );
@@ -635,8 +627,8 @@ mod tests {
         };
         assert_eq!(
             events,
-            vec![ClientKeyEvent {
-                keycode: 0xffe3,
+            vec![Key {
+                keysym: 0xffe3,
                 down: true
             }]
         );
@@ -650,8 +642,8 @@ mod tests {
         };
         assert_eq!(
             events,
-            vec![ClientKeyEvent {
-                keycode: 0x63,
+            vec![Key {
+                keysym: 0x63,
                 down: true
             }],
             "the modifier must not be pressed a second time"
@@ -714,8 +706,8 @@ mod tests {
         );
         assert_eq!(
             input.on_key(key(ctrl_l, KeyEventKind::Release, KeyModifiers::NONE)),
-            KeyOutcome::Keys(vec![ClientKeyEvent {
-                keycode: 0xffe3,
+            KeyOutcome::Keys(vec![Key {
+                keysym: 0xffe3,
                 down: false
             }])
         );
@@ -735,12 +727,12 @@ mod tests {
         assert_eq!(events.len(), 4);
         assert_eq!(
             events[0],
-            ClientKeyEvent {
-                keycode: bitmask::CONTROL,
+            Key {
+                keysym: bitmask::CONTROL,
                 down: true
             }
         );
-        assert_eq!(events[1].keycode, 0x61);
+        assert_eq!(events[1].keysym, 0x61);
         assert!(!events[3].down);
         // And nothing is left held afterwards.
         assert!(input.release_all().is_empty());
@@ -842,7 +834,7 @@ mod tests {
         let released = input.release_all();
         assert_eq!(released.len(), 3);
         assert!(released.iter().all(|e| !e.down));
-        assert_eq!(released.last().unwrap().keycode, 0xffe3);
+        assert_eq!(released.last().unwrap().keysym, 0xffe3);
         assert!(input.release_all().is_empty(), "and only once");
     }
 
@@ -861,7 +853,7 @@ mod tests {
             &metrics(),
         );
         assert_eq!(events.len(), 1);
-        assert_eq!((events[0].position_x, events[0].position_y), (37, 91));
+        assert_eq!((events[0].x, events[0].y), (37, 91));
     }
 
     #[test]
@@ -878,10 +870,7 @@ mod tests {
             &layout,
             &metrics(),
         );
-        assert_eq!(
-            (events[0].position_x, events[0].position_y),
-            (4 * 8 + 4, 5 * 17 + 8)
-        );
+        assert_eq!((events[0].x, events[0].y), (4 * 8 + 4, 5 * 17 + 8));
     }
 
     #[test]
@@ -1012,7 +1001,7 @@ mod tests {
         assert!(input.flush_motion().is_none());
         std::thread::sleep(MOTION_INTERVAL + Duration::from_millis(2));
         let flushed = input.flush_motion().expect("the last position must arrive");
-        assert_eq!((flushed.position_x, flushed.position_y), (12, 10));
+        assert_eq!((flushed.x, flushed.y), (12, 10));
         assert!(input.flush_motion().is_none(), "and only once");
     }
 
@@ -1043,11 +1032,8 @@ mod tests {
             2,
             "the held position, then the click: {events:?}"
         );
-        assert_eq!((events[0].position_x, events[0].buttons), (44, 0));
-        assert_eq!(
-            (events[1].position_x, events[1].buttons),
-            (44, button::LEFT)
-        );
+        assert_eq!((events[0].x, events[0].buttons), (44, 0));
+        assert_eq!((events[1].x, events[1].buttons), (44, button::LEFT));
     }
 
     #[test]

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -304,7 +304,7 @@ fn a_real_server_negotiates_continuous_updates() {
     // negotiation works against something that was not written to agree with us.
     let mut term = start(&["--scale", "native", "--log-file", "/tmp/desktui-live.log"]);
     assert!(
-        term.wait_for(b"continuous updates", Duration::from_secs(30)),
+        term.wait_for(b"pushing frames", Duration::from_secs(30)),
         "the server never enabled continuous updates: {}",
         tail(&term.output())
     );
@@ -524,12 +524,17 @@ fn a_real_server_answers_the_latency_probe() {
     // A measured round trip appears in the status line as a number of milliseconds.
     // Before the fix it was there too, but climbing; now it can only appear at all if a
     // fence came back.
+    //
+    // Matched on the figure alone rather than on the binding that used to follow it: the
+    // status line gained per-span colours, so an escape sequence sits between the two and
+    // no contiguous needle can span them. `ms` with the trailing pad is enough on its
+    // own -- an unmeasured round trip is drawn as dashes, so the unit only appears when
+    // there is a number in front of it.
     let start = std::time::Instant::now();
     let mut seen = false;
     while start.elapsed() < Duration::from_secs(20) {
         let out = term.output();
-        // Two samples a second apart: a real measurement stays small, the old bug grew.
-        if contains(&out, b"ms  Ctrl+") {
+        if contains(&out, b"ms  ") {
             seen = true;
             break;
         }
@@ -544,7 +549,7 @@ fn a_real_server_answers_the_latency_probe() {
     // And it must not be a figure that only grows. Sample it twice, far apart.
     let sample = |out: &[u8]| -> Option<u128> {
         let text = String::from_utf8_lossy(out).into_owned();
-        text.rmatch_indices("ms  Ctrl+").next().and_then(|(i, _)| {
+        text.rmatch_indices("ms  ").next().and_then(|(i, _)| {
             let head = &text[..i];
             let digits: String = head
                 .chars()

--- a/tests/updates.rs
+++ b/tests/updates.rs
@@ -141,7 +141,7 @@ fn continuous_updates_are_enabled_and_stop_the_request_traffic() {
         other => panic!("unexpected {other:?}"),
     }
     assert!(
-        term.wait_for(b"continuous updates", Duration::from_secs(10)),
+        term.wait_for(b"pushing frames", Duration::from_secs(10)),
         "the user was not told: {}",
         show(&term.output())
     );


### PR DESCRIPTION
The session was written against the RFB client directly: it matched on `VncEvent`, sent `X11Event`, masked fence flags by hand, ran the continuous-updates negotiation, and — since #5 — drove the extended-clipboard handshake. None of that is what the loop is about, which is composing a framebuffer and terminal input into frames, and all of it would have to be duplicated to speak a second protocol.

`src/remote` is now that seam. `Update` and `Input` carry what crosses it, `Backend` and `Connect` are what a protocol implements, `src/remote/vnc.rs` is the RFB implementation, and `session.rs` is generic over `Backend` — it no longer contains the words RFB, VNC or fence.

No behaviour changes for a VNC user, bar one string (below). This is groundwork for RDP; the plan for that is written up separately.

## What shapes the seam

**Capabilities are announced, not queried.** There is no `capabilities()` method. A session starts out believing the least — that it must ask for every frame, that latency cannot be measured, that the clipboard is lossy — and the backend says otherwise with `Update::Pushing`, `Update::LatencyAvailable` and `Update::ClipboardLossy`. That's forced by RFB, where none of it is known until `SetEncodings` is answered, so a value read at connect time would be wrong.

**Mechanics stay behind it.** Re-arming continuous updates after a resize, echoing a server fence with the request bit cleared, the payload marking our own latency probe, and the whole clipboard dance — caps negotiation, notify versus provide, the size limit, the CRLF wire length, holding announced text until the remote asks — were all in the session. They're the backend's now.

What's left in the session is the one part that genuinely belongs to it: telling the user when what they pasted won't arrive whole. The backend chooses the message and coerces to Latin-1 when it must; the session counts what won't survive and warns. A substitution nobody warned about is one they find later, in whatever they pasted into.

**`Backend::recv` must be cancel-safe.** It's called from a `select!`, so it's dropped and re-entered tens of times a second. An implementation that has taken an update off the wire must not await anything before returning it, or a render tick eats a frame. The RFB backend queues the replies it owes in an outbox and flushes them *before* the next read. Documented on the trait, because any second backend needs the same discipline.

## Incidental

- **One user-visible string changed.** The continuous-updates note was "continuous updates: the server pushes frames"; it's now "the remote is pushing frames", because the session no longer knows what the RFB extension is called.
- **`Vnc::new` grew a named options struct.** Five positional arguments became `vnc::Options { quality, compression, local_cursor, clipboard }`.
- **Fixed a stale needle in the live suite.** `a_real_server_answers_the_latency_probe` has been failing since d990946, which lowercased the status line's binding *and* gave it per-span colours — so an escape sequence now sits between the round-trip figure and the binding, and no contiguous match can span them whatever the case. It matches the figure alone now, which is still a real assertion: an unmeasured round trip draws dashes, so the unit only appears with a number in front of it.
- **One regression found and fixed during the work.** The backend's size tracker started at `(0, 0)` rather than the `ServerInit` size, so a server answering `SetEncodings` before sending any rectangle would have had continuous updates enabled for a 0×0 rect — a black screen. Test added.

## Verification

| suite | result |
|---|---|
| `cargo test` | 372 passed |
| `cargo test --test resize --test updates -- --ignored` | 2 passed |
| `make test-live` (real TigerVNC) | 14 passed |
| `cargo clippy --all-targets -- -D warnings` | clean |

Worth noting that #5's four clipboard tests pass unmodified through the relocated code, including `a_real_server_negotiates_the_extended_clipboard` against a real server. Seven unit tests were added in `vnc.rs` for the paste decision, now that it's backend logic and testable without a server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)