### PR TITLE
Send our clipboard caps as a reply, not as an opening

### DIFF
--- a/src/remote/vnc.rs
+++ b/src/remote/vnc.rs
@@ -288,6 +288,13 @@ impl State {
                 // leaves us on the lossy path regardless.
                 tracing::debug!("extended clipboard negotiated: {caps:?}");
                 self.clipboard = Some(caps);
+                // Our own caps, which the server is owed and which nothing above
+                // decides: text is the only format a terminal can hold, and the
+                // unsolicited size of zero says we would rather be told the clipboard
+                // changed than handed a copy of every remote selection. This is the
+                // first extended message we are allowed to send, and it has to go
+                // before any notify or provide.
+                self.outbox.push_back(X11Event::ClipboardCaps);
                 Some(Update::ClipboardLossy(!self.clipboard_is_usable()))
             }
             VncEvent::ClipboardNotify { text } => {
@@ -696,6 +703,30 @@ mod tests {
             1024,
         )));
         assert!(matches!(update, Some(Update::ClipboardLossy(false))));
+    }
+
+    #[test]
+    fn our_caps_answer_the_servers_and_are_not_offered_before_them() {
+        // The extension's handshake runs one way only: the pseudo-encoding in
+        // `SetEncodings` is the offer, the server's caps are the acceptance, and ours
+        // are the reply. Sending ours unasked cost the whole session against macOS
+        // Screen Sharing, which reads the negative length of an extended
+        // `ClientCutText` as a protocol error and hangs up mid-handshake.
+        let mut state = State {
+            clipboard_wanted: true,
+            ..State::default()
+        };
+        assert!(
+            state.outbox.is_empty(),
+            "nothing extended may go out before the server's caps"
+        );
+
+        state.translate(VncEvent::ClipboardCaps(caps_taking(1024)));
+
+        assert!(
+            matches!(state.outbox.pop_front(), Some(X11Event::ClipboardCaps)),
+            "the server's caps are owed a reply, and it comes first"
+        );
     }
 
     #[test]

--- a/src/rfb/client/connection.rs
+++ b/src/rfb/client/connection.rs
@@ -123,18 +123,14 @@ impl VncInner {
             .await?;
 
         trace!("client encodings: {:?}", encodings);
-        let extended_clipboard = encodings.contains(&VncEncoding::ExtendedClipboardPseudo);
         send_client_encoding(&mut stream, encodings, quality, compression).await?;
 
-        // A server that understands the extension answers the `SetEncodings` above with
-        // a `caps` message. Ours goes the other way now: text is the only format a
-        // terminal can hold, and the size of zero says we would rather be told the
-        // clipboard changed than handed a copy of every remote selection.
-        if extended_clipboard {
-            ClientMsg::ExtendedCutText(clipboard::caps())
-                .write(&mut stream)
-                .await?;
-        }
+        // Nothing extended goes out here. A server that understands the extension
+        // answers the `SetEncodings` above with a `caps` message, and ours is the reply
+        // to that -- see [`X11Event::ClipboardCaps`]. Sending it unasked costs a server
+        // that does not understand the extension the whole session: the length of an
+        // extended `ClientCutText` is negative, and macOS's Screen Sharing reads that as
+        // a protocol error and hangs up.
 
         // Start with a non-incremental request. Besides fetching the first frame,
         // this is the only way to learn the screen layout: a server supporting
@@ -209,6 +205,7 @@ impl VncInner {
                 ClientMsg::PointerEvent(mouse.x, mouse.y, mouse.buttons)
             }
             X11Event::CopyText(text) => ClientMsg::ClientCutText(text),
+            X11Event::ClipboardCaps => ClientMsg::ExtendedCutText(clipboard::caps()),
             X11Event::ClipboardRequest => ClientMsg::ExtendedCutText(clipboard::request()),
             X11Event::ClipboardNotify => ClientMsg::ExtendedCutText(clipboard::notify()),
             X11Event::ClipboardProvide(text) => {
@@ -1010,6 +1007,110 @@ mod tests {
             ),
             "{events:?}"
         );
+    }
+
+    /// A stream that reads a canned `ServerInit` and remembers what was written back.
+    ///
+    /// Cloneable and `'static` because `VncInner::new` takes the stream by value and
+    /// hands it to spawned tasks; the recording half stays reachable from the test.
+    #[derive(Clone, Default)]
+    struct Duplex {
+        inbound: Arc<std::sync::Mutex<std::collections::VecDeque<u8>>>,
+        outbound: Arc<std::sync::Mutex<Vec<u8>>>,
+    }
+
+    impl AsyncRead for Duplex {
+        fn poll_read(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            let mut inbound = self.inbound.lock().unwrap();
+            while buf.remaining() > 0 {
+                match inbound.pop_front() {
+                    Some(byte) => buf.put_slice(&[byte]),
+                    // Running dry is end of stream, so the decode task stops rather
+                    // than parking forever on a script that said all it had to say.
+                    None => break,
+                }
+            }
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for Duplex {
+        fn poll_write(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            data: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            self.outbound.lock().unwrap().extend_from_slice(data);
+            std::task::Poll::Ready(Ok(data.len()))
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    /// A `ServerInit` for an 800x600 desktop called "test".
+    fn server_init() -> Vec<u8> {
+        let mut bytes = 800u16.to_be_bytes().to_vec();
+        bytes.extend_from_slice(&600u16.to_be_bytes());
+        bytes.extend_from_slice(&[32, 24, 0, 1]); // bpp, depth, big endian, true colour
+        bytes.extend_from_slice(&[0, 255, 0, 255, 0, 255]); // the three maxima
+        bytes.extend_from_slice(&[16, 8, 0, 0, 0, 0]); // the three shifts, then padding
+        bytes.extend_from_slice(&4u32.to_be_bytes());
+        bytes.extend_from_slice(b"test");
+        bytes
+    }
+
+    #[tokio::test]
+    async fn setting_up_sends_nothing_the_server_has_not_agreed_to() {
+        // The extended clipboard is offered by naming its pseudo-encoding and agreed to
+        // by the server answering with `caps`. Sending our own caps as part of setup
+        // jumped that second step, and it is not a harmless extra: the length of an
+        // extended `ClientCutText` is negative, and macOS's Screen Sharing reads one it
+        // never agreed to as a protocol error and closes the connection -- so the
+        // session died moments after the password was accepted.
+        let stream = Duplex::default();
+        stream
+            .inbound
+            .lock()
+            .unwrap()
+            .extend(server_init().into_iter());
+
+        let inner = VncInner::new(
+            stream.clone(),
+            true,
+            Some(PixelFormat::bgra()),
+            vec![VncEncoding::Raw, VncEncoding::ExtendedClipboardPseudo],
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let written = stream.outbound.lock().unwrap().clone();
+        assert_eq!(written[0], 1, "ClientInit's shared flag comes first");
+        assert_eq!(written[1], 0, "then SetPixelFormat");
+        assert_eq!(written[21], 2, "then SetEncodings, and nothing else");
+        assert!(
+            !written[21..].contains(&6),
+            "a ClientCutText went out before the server offered a clipboard: {written:?}"
+        );
+
+        drop(inner);
     }
 
     #[tokio::test]

--- a/src/rfb/event.rs
+++ b/src/rfb/event.rs
@@ -164,6 +164,13 @@ pub enum X11Event {
     PointerEvent(Pointer),
     /// Send text to the server's clipboard, the legacy way. Latin-1 only.
     CopyText(String),
+    /// Tell the server what we accept on the extended clipboard.
+    ///
+    /// The reply to [`VncEvent::ClipboardCaps`], and only ever that: a server which
+    /// never sent its own caps has not agreed to the extension, and an extended
+    /// message carries a negative length that such a server may treat as a protocol
+    /// error. This is also the first extended message we may send.
+    ClipboardCaps,
     /// Ask the server for the clipboard it announced with
     /// [`VncEvent::ClipboardNotify`].
     ClipboardRequest,


### PR DESCRIPTION
macOS Screen Sharing dropped the connection moments after the password was accepted, and the error the user saw -- "unexpected end of file" -- pointed at the auth that had in fact just succeeded. Replaying the handshake against a real server put the seam two messages later: version, security type 2, challenge, SecurityResult 0, a ServerInit naming the desktop, and then a hang-up on the next read. Bisecting what the client says after ServerInit found the one message that provokes it, and the pseudo-encoding is not it -- asking for ExtendedClipboard is harmless, and only the caps message that followed unasked closed the connection.

The extension's handshake runs offer, accept, reply: naming the pseudo-encoding in SetEncodings is the offer, the server's caps are the acceptance, and ours are the reply. Setup jumped to the reply. That is not a harmless extra byte -- an extended ClientCutText carries a negative length, which is how it tells itself apart from the legacy message, and a server that never agreed to the extension is entitled to read one as a protocol error. Apple's does. The doc comment on ClipboardCaps already said the rule the code broke: nothing extended may be sent before it.

So the caps go out in answer to the server's, the way ServerFence and ClipboardNotify replies already travel -- up as an event, back down as an X11Event. Everything downstream was gated on those caps having arrived, so nothing else moves.

Two tests. One pins the reply. The other pins what setup writes, which nothing guarded before, and it is the one that matters: this bug was an extra message on the wire during setup, invisible to every test that reads a canned server stream.